### PR TITLE
Split out AliasCleaner service

### DIFF
--- a/pathauto.services.yml
+++ b/pathauto.services.yml
@@ -2,3 +2,8 @@ services:
   pathauto.manager:
     class: Drupal\pathauto\PathautoManager
     arguments: ['@config.factory', '@language_manager', '@cache.default', '@module_handler', '@token']
+  pathauto.alias_cleaner:
+    class: Drupal\pathauto\AliasCleaner
+    arguments: ['@config.factory', '@pathauto.alias_storage_helper']
+  pathauto.alias_storage_helper:
+    class: Drupal\pathauto\AliasStorageHelper

--- a/src/AliasCleaner.php
+++ b/src/AliasCleaner.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\pathauto\AliasCleaner
+ */
+
+namespace Drupal\pathauto;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Provides an alias cleaner.
+ */
+class AliasCleaner implements AliasCleanerInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The alias storage helper.
+   *
+   * @var \Drupal\pathauto\AliasStorageHelper
+   */
+  protected $aliasStorageHelper;
+
+  /**
+   * Alias max length.
+   *
+   * @var int
+   */
+  protected $aliasMaxLength;
+
+  /**
+   * Creates a new AliasCleaner.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param AliasStorageHelper $alias_storage_helper
+   *   The alias storage helper.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, AliasStorageHelper $alias_storage_helper) {
+    $this->configFactory = $config_factory;
+    $this->aliasStorageHelper = $alias_storage_helper;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cleanAlias($alias) {
+    if (!isset($this->aliasMaxLength)) {
+      $config = $this->configFactory->get('pathauto.settings');
+      $this->aliasMaxLength = min($config->get('max_length'), $this->aliasStorageHelper->getAliasSchemaMaxLength());
+    }
+
+    $output = $alias;
+
+    // Trim duplicate, leading, and trailing separators. Do this before cleaning
+    // backslashes since a pattern like "[token1]/[token2]-[token3]/[token4]"
+    // could end up like "value1/-/value2" and if backslashes were cleaned first
+    // this would result in a duplicate blackslash.
+    $output = $this->getCleanSeparators($output);
+
+    // Trim duplicate, leading, and trailing backslashes.
+    $output = $this->getCleanSeparators($output, '/');
+
+    // Shorten to a logical place based on word boundaries.
+    $output = Unicode::truncate($output, $this->aliasMaxLength, TRUE);
+
+    return $output;
+  }
+
+  /**
+   * Trims duplicate, leading, and trailing separators from a string.
+   *
+   * @param string $string
+   *   The string to clean path separators from.
+   * @param string $separator
+   *   The path separator to use when cleaning.
+   *
+   * @return string
+   *   The cleaned version of the string.
+   *
+   * @see pathauto_cleanstring()
+   * @see pathauto_clean_alias()
+   */
+  protected function getCleanSeparators($string, $separator = NULL) {
+    $config = $this->configFactory->get('pathauto.settings');
+
+    if (!isset($separator)) {
+      $separator = $config->get('separator');
+    }
+
+    $output = $string;
+
+    if (strlen($separator)) {
+      // Trim any leading or trailing separators.
+      $output = trim($output, $separator);
+
+      // Escape the separator for use in regular expressions.
+      $seppattern = preg_quote($separator, '/');
+
+      // Replace multiple separators with a single one.
+      $output = preg_replace("/$seppattern+/", $separator, $output);
+
+      // Replace trailing separators around slashes.
+      if ($separator !== '/') {
+        $output = preg_replace("/\/+$seppattern\/+|$seppattern\/+|\/+$seppattern/", "/", $output);
+      }
+    }
+
+    return $output;
+  }
+
+}

--- a/src/AliasCleanerInterface.php
+++ b/src/AliasCleanerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\pathauto\AliasCleanerInterface
+ */
+namespace Drupal\pathauto;
+
+/**
+ * @todo add class comment.
+ */
+interface AliasCleanerInterface {
+
+  /**
+   * Clean up an URL alias.
+   *
+   * Performs the following alterations:
+   * - Trim duplicate, leading, and trailing back-slashes.
+   * - Trim duplicate, leading, and trailing separators.
+   * - Shorten to a desired length and logical position based on word boundaries.
+   *
+   * @param string $alias
+   *   A string with the URL alias to clean up.
+   *
+   * @return string
+   *   The cleaned URL alias.
+   */
+  public function cleanAlias($alias);
+}

--- a/src/AliasStorageHelper.php
+++ b/src/AliasStorageHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\pathauto\AliasSchemaHelper
+ */
+
+namespace Drupal\pathauto;
+
+/**
+ * Provides helper methods for accessing alias storage.
+ */
+class AliasStorageHelper {
+
+  /**
+   * Alias schema max length.
+   *
+   * @var int
+   */
+  protected $aliasSchemaMaxLength;
+
+  /**
+   * Fetch the maximum length of the {url_alias}.alias field from the schema.
+   *
+   * @return int
+   *   An integer of the maximum URL alias length allowed by the database.
+   */
+  public function getAliasSchemaMaxLength() {
+    if (!isset($this->aliasSchemaMaxLength)) {
+      $schema = drupal_get_schema('url_alias');
+      $this->aliasSchemaMaxLength = $schema['fields']['alias']['length'];
+    }
+    return $this->aliasSchemaMaxLength;
+  }
+
+}


### PR DESCRIPTION
This splits out a AliasCleaner service to simplify the logic in PathautoManager.

It also creates a AliasStorageHelper and moves the methods that access the maxlength values there.
