### PR TITLE
Move defined constants to new interface

### DIFF
--- a/pathauto.inc
+++ b/pathauto.inc
@@ -16,46 +16,6 @@ use Drupal\Core\Language\Language;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
- * Case should be left as is in the generated path.
- */
-define('PATHAUTO_CASE_LEAVE_ASIS', 0);
-
-/**
- * Case should be lowercased in the generated path.
- */
-define('PATHAUTO_CASE_LOWER', 1);
-
-/**
- * "Do nothing. Leave the old alias intact."
- */
-define('PATHAUTO_UPDATE_ACTION_NO_NEW', 0);
-
-/**
- * "Create a new alias. Leave the existing alias functioning."
- */
-define('PATHAUTO_UPDATE_ACTION_LEAVE', 1);
-
-/**
- * "Create a new alias. Delete the old alias."
- */
-define('PATHAUTO_UPDATE_ACTION_DELETE', 2);
-
-/**
- * Remove the punctuation from the alias.
- */
-define('PATHAUTO_PUNCTUATION_REMOVE', 0);
-
-/**
- * Replace the punctuation with the separator in the alias.
- */
-define('PATHAUTO_PUNCTUATION_REPLACE', 1);
-
-/**
- * Leave the punctuation as it is in the alias.
- */
-define('PATHAUTO_PUNCTUATION_DO_NOTHING', 2);
-
-/**
  * Fetches an existing URL alias given a path and optional language.
  *
  * @param string $source

--- a/src/AliasStorageHelper.php
+++ b/src/AliasStorageHelper.php
@@ -87,16 +87,16 @@ class AliasStorageHelper implements AliasStorageHelperInterface {
       // If there is already an alias, respect some update actions.
       if (!empty($existing_alias)) {
         switch ($config->get('update_action')) {
-          case PATHAUTO_UPDATE_ACTION_NO_NEW:
+          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW:
             // Do not create the alias.
             return NULL;
 
-          case PATHAUTO_UPDATE_ACTION_LEAVE:
+          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_LEAVE:
             // Create a new alias instead of overwriting the existing by leaving
             // $path['pid'] empty.
             break;
 
-          case PATHAUTO_UPDATE_ACTION_DELETE:
+          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE:
             // The delete actions should overwrite the existing alias.
             $path['pid'] = $existing_alias['pid'];
             break;

--- a/src/AliasStorageHelper.php
+++ b/src/AliasStorageHelper.php
@@ -87,16 +87,16 @@ class AliasStorageHelper implements AliasStorageHelperInterface {
       // If there is already an alias, respect some update actions.
       if (!empty($existing_alias)) {
         switch ($config->get('update_action')) {
-          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW:
+          case PathautoManagerInterface::UPDATE_ACTION_NO_NEW:
             // Do not create the alias.
             return NULL;
 
-          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_LEAVE:
+          case PathautoManagerInterface::UPDATE_ACTION_LEAVE:
             // Create a new alias instead of overwriting the existing by leaving
             // $path['pid'] empty.
             break;
 
-          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE:
+          case PathautoManagerInterface::UPDATE_ACTION_DELETE:
             // The delete actions should overwrite the existing alias.
             $path['pid'] = $existing_alias['pid'];
             break;

--- a/src/Form/PathautoSettingsForm.php
+++ b/src/Form/PathautoSettingsForm.php
@@ -9,6 +9,7 @@ namespace Drupal\pathauto\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Component\Utility\String;
+use Drupal\pathauto\PathautoManagerInterface;
 
 /**
  * Configure file system settings for this site.
@@ -52,8 +53,8 @@ class PathautoSettingsForm extends ConfigFormBase {
       '#title' => t('Character case'),
       '#default_value' => $config->get('case'),
       '#options' => array(
-        PATHAUTO_CASE_LEAVE_ASIS => t('Leave case the same as source token values.'),
-        PATHAUTO_CASE_LOWER => t('Change to lower case'),
+        PathautoManagerInterface::PATHAUTO_CASE_LEAVE_ASIS => t('Leave case the same as source token values.'),
+        PathautoManagerInterface::PATHAUTO_CASE_LOWER => t('Change to lower case'),
       ),
     );
 
@@ -94,9 +95,9 @@ class PathautoSettingsForm extends ConfigFormBase {
       '#title' => t('Update action'),
       '#default_value' => $config->get('update_action'),
       '#options' => array(
-        PATHAUTO_UPDATE_ACTION_NO_NEW => t('Do nothing. Leave the old alias intact.'),
-        PATHAUTO_UPDATE_ACTION_LEAVE => t('Create a new alias. Leave the existing alias functioning.'),
-        PATHAUTO_UPDATE_ACTION_DELETE => t('Create a new alias. Delete the old alias.'),
+        PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW => t('Do nothing. Leave the old alias intact.'),
+        PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_LEAVE => t('Create a new alias. Leave the existing alias functioning.'),
+        PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE => t('Create a new alias. Delete the old alias.'),
       ),
       '#description' => $description,
     );
@@ -133,18 +134,18 @@ class PathautoSettingsForm extends ConfigFormBase {
     $punctuation = \Drupal::service('pathauto.manager')->getPunctuationCharacters();
 
     foreach ($punctuation as $name => $details) {
-      $details['default'] = PATHAUTO_PUNCTUATION_REMOVE;
+      $details['default'] = PathautoManagerInterface::PATHAUTO_PUNCTUATION_REMOVE;
       if ($details['value'] == $config->get('separator')) {
-        $details['default'] = PATHAUTO_PUNCTUATION_REPLACE;
+        $details['default'] = PathautoManagerInterface::PATHAUTO_PUNCTUATION_REPLACE;
       }
       $form['punctuation']['punctuation_' . $name] = array(
         '#type' => 'select',
         '#title' => $details['name'] . ' (<code>' . String::checkPlain($details['value']) . '</code>)',
         '#default_value' => $details['default'],
         '#options' => array(
-          PATHAUTO_PUNCTUATION_REMOVE => t('Remove'),
-          PATHAUTO_PUNCTUATION_REPLACE => t('Replace by separator'),
-          PATHAUTO_PUNCTUATION_DO_NOTHING => t('No action (do not replace)'),
+          PathautoManagerInterface::PATHAUTO_PUNCTUATION_REMOVE => t('Remove'),
+          PathautoManagerInterface::PATHAUTO_PUNCTUATION_REPLACE => t('Replace by separator'),
+          PathautoManagerInterface::PATHAUTO_PUNCTUATION_DO_NOTHING => t('No action (do not replace)'),
         ),
       );
     }

--- a/src/Form/PathautoSettingsForm.php
+++ b/src/Form/PathautoSettingsForm.php
@@ -17,6 +17,16 @@ use Drupal\pathauto\PathautoManagerInterface;
 class PathautoSettingsForm extends ConfigFormBase {
 
   /**
+   * Case should be left as is in the generated path.
+   */
+  const PATHAUTO_CASE_LEAVE_ASIS = 0;
+
+  /**
+   * Case should be lowercased in the generated path.
+   */
+  const PATHAUTO_CASE_LOWER = 1;
+
+  /**
    * {@inheritdoc}
    */
   public function getFormId() {
@@ -53,8 +63,8 @@ class PathautoSettingsForm extends ConfigFormBase {
       '#title' => t('Character case'),
       '#default_value' => $config->get('case'),
       '#options' => array(
-        PathautoManagerInterface::PATHAUTO_CASE_LEAVE_ASIS => t('Leave case the same as source token values.'),
-        PathautoManagerInterface::PATHAUTO_CASE_LOWER => t('Change to lower case'),
+        self::PATHAUTO_CASE_LEAVE_ASIS => t('Leave case the same as source token values.'),
+        self::PATHAUTO_CASE_LOWER => t('Change to lower case'),
       ),
     );
 

--- a/src/Form/PathautoSettingsForm.php
+++ b/src/Form/PathautoSettingsForm.php
@@ -19,12 +19,12 @@ class PathautoSettingsForm extends ConfigFormBase {
   /**
    * Case should be left as is in the generated path.
    */
-  const PATHAUTO_CASE_LEAVE_ASIS = 0;
+  const CASE_LEAVE_ASIS = 0;
 
   /**
    * Case should be lowercased in the generated path.
    */
-  const PATHAUTO_CASE_LOWER = 1;
+  const CASE_LOWER = 1;
 
   /**
    * {@inheritdoc}
@@ -63,8 +63,8 @@ class PathautoSettingsForm extends ConfigFormBase {
       '#title' => t('Character case'),
       '#default_value' => $config->get('case'),
       '#options' => array(
-        self::PATHAUTO_CASE_LEAVE_ASIS => t('Leave case the same as source token values.'),
-        self::PATHAUTO_CASE_LOWER => t('Change to lower case'),
+        self::CASE_LEAVE_ASIS => t('Leave case the same as source token values.'),
+        self::CASE_LOWER => t('Change to lower case'),
       ),
     );
 
@@ -105,9 +105,9 @@ class PathautoSettingsForm extends ConfigFormBase {
       '#title' => t('Update action'),
       '#default_value' => $config->get('update_action'),
       '#options' => array(
-        PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW => t('Do nothing. Leave the old alias intact.'),
-        PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_LEAVE => t('Create a new alias. Leave the existing alias functioning.'),
-        PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE => t('Create a new alias. Delete the old alias.'),
+        PathautoManagerInterface::UPDATE_ACTION_NO_NEW => t('Do nothing. Leave the old alias intact.'),
+        PathautoManagerInterface::UPDATE_ACTION_LEAVE => t('Create a new alias. Leave the existing alias functioning.'),
+        PathautoManagerInterface::UPDATE_ACTION_DELETE => t('Create a new alias. Delete the old alias.'),
       ),
       '#description' => $description,
     );
@@ -144,18 +144,18 @@ class PathautoSettingsForm extends ConfigFormBase {
     $punctuation = \Drupal::service('pathauto.manager')->getPunctuationCharacters();
 
     foreach ($punctuation as $name => $details) {
-      $details['default'] = PathautoManagerInterface::PATHAUTO_PUNCTUATION_REMOVE;
+      $details['default'] = PathautoManagerInterface::PUNCTUATION_REMOVE;
       if ($details['value'] == $config->get('separator')) {
-        $details['default'] = PathautoManagerInterface::PATHAUTO_PUNCTUATION_REPLACE;
+        $details['default'] = PathautoManagerInterface::PUNCTUATION_REPLACE;
       }
       $form['punctuation']['punctuation_' . $name] = array(
         '#type' => 'select',
         '#title' => $details['name'] . ' (<code>' . String::checkPlain($details['value']) . '</code>)',
         '#default_value' => $details['default'],
         '#options' => array(
-          PathautoManagerInterface::PATHAUTO_PUNCTUATION_REMOVE => t('Remove'),
-          PathautoManagerInterface::PATHAUTO_PUNCTUATION_REPLACE => t('Replace by separator'),
-          PathautoManagerInterface::PATHAUTO_PUNCTUATION_DO_NOTHING => t('No action (do not replace)'),
+          PathautoManagerInterface::PUNCTUATION_REMOVE => t('Remove'),
+          PathautoManagerInterface::PUNCTUATION_REPLACE => t('Replace by separator'),
+          PathautoManagerInterface::PUNCTUATION_DO_NOTHING => t('No action (do not replace)'),
         ),
       );
     }

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -16,7 +16,7 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Utility\Token;
 
-class PathautoManager {
+class PathautoManager implements PathautoManagerInterface {
 
   /**
    * Calculated settings cache.
@@ -128,32 +128,7 @@ class PathautoManager {
   }
 
   /**
-   * Clean up a string segment to be used in an URL alias.
-   *
-   * Performs the following possible alterations:
-   * - Remove all HTML tags.
-   * - Process the string through the transliteration module.
-   * - Replace or remove punctuation with the separator character.
-   * - Remove back-slashes.
-   * - Replace non-ascii and non-numeric characters with the separator.
-   * - Remove common words.
-   * - Replace whitespace with the separator character.
-   * - Trim duplicate, leading, and trailing separators.
-   * - Convert to lower-case.
-   * - Shorten to a desired length and logical position based on word boundaries.
-   *
-   * This function should *not* be called on URL alias or path strings
-   * because it is assumed that they are already clean.
-   *
-   * @param string $string
-   *   A string to clean.
-   * @param array $options
-   *   (optional) A keyed array of settings and flags to control the Pathauto
-   *   clean string replacement process. Supported options are:
-   *   - langcode: A language code to be used when translating strings.
-   *
-   * @return string
-   *   The cleaned string.
+   * {@inheritdoc}
    */
   public function cleanString($string, array $options = array()) {
     if (empty($this->cleanStringCache)) {
@@ -175,15 +150,15 @@ class PathautoManager {
       foreach ($punctuation as $name => $details) {
         $action = $config->get('punctuation_' . $name);
         switch ($action) {
-          case PATHAUTO_PUNCTUATION_REMOVE:
+          case PathautoManagerInterface::PATHAUTO_PUNCTUATION_REMOVE:
             $cache['punctuation'][$details['value']] = '';
             $this->cleanStringCache;
 
-          case PATHAUTO_PUNCTUATION_REPLACE:
+          case PathautoManagerInterface::PATHAUTO_PUNCTUATION_REPLACE:
             $this->cleanStringCache['punctuation'][$details['value']] = $this->cleanStringCache['separator'];
             break;
 
-          case PATHAUTO_PUNCTUATION_DO_NOTHING:
+          case PathautoManagerInterface::PATHAUTO_PUNCTUATION_DO_NOTHING:
             // Literally do nothing.
             break;
         }
@@ -272,15 +247,7 @@ class PathautoManager {
 
 
   /**
-   * Return an array of arrays for punctuation values.
-   *
-   * Returns an array of arrays for punctuation values keyed by a name, including
-   * the value and a textual description.
-   * Can and should be expanded to include "all" non text punctuation values.
-   *
-   * @return array
-   *   An array of arrays for punctuation values keyed by a name, including the
-   *   value and a textual description.
+   * {@inheritdoc}
    */
   public function getPunctuationCharacters() {
     if (empty($this->punctuationCharacters)) {
@@ -337,32 +304,7 @@ class PathautoManager {
 
 
   /**
-   * Apply patterns to create an alias.
-   *
-   * @param string $module
-   *   The name of your module (e.g., 'node').
-   * @param string $op
-   *   Operation being performed on the content being aliased
-   *   ('insert', 'update', 'return', or 'bulkupdate').
-   * @param string $source
-   *   An internal Drupal path to be aliased.
-   * @param array $data
-   *   An array of keyed objects to pass to token_replace(). For simple
-   *   replacement scenarios 'node', 'user', and others are common keys, with an
-   *   accompanying node or user object being the value. Some token types, like
-   *   'site', do not require any explicit information from $data and can be
-   *   replaced even if it is empty.
-   * @param string $type
-   *   For modules which provided pattern items in hook_pathauto(),
-   *   the relevant identifier for the specific item to be aliased
-   *   (e.g., $node->type).
-   * @param string $language
-   *   A string specify the path's language.
-   *
-   * @return array|string
-   *   The alias that was created.
-   *
-   * @see _pathauto_set_alias()
+   * {@inheritdoc}
    */
   public function createAlias($module, $op, $source, $data, $type = NULL, $language = LanguageInterface::LANGCODE_NOT_SPECIFIED) {
     $config = $this->configFactory->get('pathauto.settings');
@@ -392,7 +334,7 @@ class PathautoManager {
     if ($op == 'update' || $op == 'bulkupdate') {
       if ($existing_alias = _pathauto_existing_alias_data($source, $language)) {
         switch ($config->get('update_action')) {
-          case PATHAUTO_UPDATE_ACTION_NO_NEW:
+          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW:
             // If an alias already exists,
             // and the update action is set to do nothing,
             // then gosh-darn it, do nothing.
@@ -458,14 +400,7 @@ class PathautoManager {
   }
 
   /**
-   * Load an URL alias pattern by entity, bundle, and language.
-   *
-   * @param $entity_type_id
-   *   An entity (e.g. node, taxonomy, user, etc.)
-   * @param $bundle
-   *   A bundle (e.g. content type, vocabulary ID, etc.)
-   * @param $language
-   *   A language code, defaults to the LANGUAGE_NONE constant.
+   * {@inheritdoc}
    */
   public function getPatternByEntity($entity_type_id, $bundle = '', $language = LanguageInterface::LANGCODE_NOT_SPECIFIED) {
     $config = $this->configFactory->get('pathauto.pattern');

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -150,15 +150,15 @@ class PathautoManager implements PathautoManagerInterface {
       foreach ($punctuation as $name => $details) {
         $action = $config->get('punctuation_' . $name);
         switch ($action) {
-          case PathautoManagerInterface::PATHAUTO_PUNCTUATION_REMOVE:
+          case PathautoManagerInterface::PUNCTUATION_REMOVE:
             $cache['punctuation'][$details['value']] = '';
             $this->cleanStringCache;
 
-          case PathautoManagerInterface::PATHAUTO_PUNCTUATION_REPLACE:
+          case PathautoManagerInterface::PUNCTUATION_REPLACE:
             $this->cleanStringCache['punctuation'][$details['value']] = $this->cleanStringCache['separator'];
             break;
 
-          case PathautoManagerInterface::PATHAUTO_PUNCTUATION_DO_NOTHING:
+          case PathautoManagerInterface::PUNCTUATION_DO_NOTHING:
             // Literally do nothing.
             break;
         }
@@ -334,7 +334,7 @@ class PathautoManager implements PathautoManagerInterface {
     if ($op == 'update' || $op == 'bulkupdate') {
       if ($existing_alias = _pathauto_existing_alias_data($source, $language)) {
         switch ($config->get('update_action')) {
-          case PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW:
+          case PathautoManagerInterface::UPDATE_ACTION_NO_NEW:
             // If an alias already exists,
             // and the update action is set to do nothing,
             // then gosh-darn it, do nothing.

--- a/src/PathautoManagerInterface.php
+++ b/src/PathautoManagerInterface.php
@@ -14,16 +14,6 @@ use Drupal\Core\Language\LanguageInterface;
 interface PathautoManagerInterface {
 
   /**
-   * Case should be left as is in the generated path.
-   */
-  const PATHAUTO_CASE_LEAVE_ASIS = 0;
-
-  /**
-   * Case should be lowercased in the generated path.
-   */
-  const PATHAUTO_CASE_LOWER = 1;
-
-  /**
    * "Do nothing. Leave the old alias intact."
    */
   const PATHAUTO_UPDATE_ACTION_NO_NEW = 0;

--- a/src/PathautoManagerInterface.php
+++ b/src/PathautoManagerInterface.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\pathauto\PathautoManagerInterface
+ */
+
+namespace Drupal\pathauto;
+
+use Drupal\Core\Language\LanguageInterface;
+
+/**
+ * Provides and interface for PathautoManager.
+ */
+interface PathautoManagerInterface {
+
+  /**
+   * Case should be left as is in the generated path.
+   */
+  const PATHAUTO_CASE_LEAVE_ASIS = 0;
+
+  /**
+   * Case should be lowercased in the generated path.
+   */
+  const PATHAUTO_CASE_LOWER = 1;
+
+  /**
+   * "Do nothing. Leave the old alias intact."
+   */
+  const PATHAUTO_UPDATE_ACTION_NO_NEW = 0;
+
+  /**
+   * "Create a new alias. Leave the existing alias functioning."
+   */
+  const PATHAUTO_UPDATE_ACTION_LEAVE = 1;
+
+  /**
+   * "Create a new alias. Delete the old alias."
+   */
+  const PATHAUTO_UPDATE_ACTION_DELETE = 2;
+
+  /**
+   * Remove the punctuation from the alias.
+   */
+  const PATHAUTO_PUNCTUATION_REMOVE = 0;
+
+  /**
+   * Replace the punctuation with the separator in the alias.
+   */
+  const PATHAUTO_PUNCTUATION_REPLACE = 1;
+
+  /**
+   * Leave the punctuation as it is in the alias.
+   */
+  const PATHAUTO_PUNCTUATION_DO_NOTHING = 2;
+
+  /**
+   * Resets internal caches.
+   */
+  public function resetCaches();
+
+  /**
+   * Clean up a string segment to be used in an URL alias.
+   *
+   * Performs the following possible alterations:
+   * - Remove all HTML tags.
+   * - Process the string through the transliteration module.
+   * - Replace or remove punctuation with the separator character.
+   * - Remove back-slashes.
+   * - Replace non-ascii and non-numeric characters with the separator.
+   * - Remove common words.
+   * - Replace whitespace with the separator character.
+   * - Trim duplicate, leading, and trailing separators.
+   * - Convert to lower-case.
+   * - Shorten to a desired length and logical position based on word boundaries.
+   *
+   * This function should *not* be called on URL alias or path strings
+   * because it is assumed that they are already clean.
+   *
+   * @param string $string
+   *   A string to clean.
+   * @param array $options
+   *   (optional) A keyed array of settings and flags to control the Pathauto
+   *   clean string replacement process. Supported options are:
+   *   - langcode: A language code to be used when translating strings.
+   *
+   * @return string
+   *   The cleaned string.
+   */
+  public function cleanString($string, array $options = array());
+
+  /**
+   * Load an URL alias pattern by entity, bundle, and language.
+   *
+   * @param $entity_type_id
+   *   An entity (e.g. node, taxonomy, user, etc.)
+   * @param $bundle
+   *   A bundle (e.g. content type, vocabulary ID, etc.)
+   * @param $language
+   *   A language code, defaults to the LANGUAGE_NONE constant.
+   */
+  public function getPatternByEntity($entity_type_id, $bundle = '', $language = LanguageInterface::LANGCODE_NOT_SPECIFIED);
+
+  /**
+   * Apply patterns to create an alias.
+   *
+   * @param string $module
+   *   The name of your module (e.g., 'node').
+   * @param string $op
+   *   Operation being performed on the content being aliased
+   *   ('insert', 'update', 'return', or 'bulkupdate').
+   * @param string $source
+   *   An internal Drupal path to be aliased.
+   * @param array $data
+   *   An array of keyed objects to pass to token_replace(). For simple
+   *   replacement scenarios 'node', 'user', and others are common keys, with an
+   *   accompanying node or user object being the value. Some token types, like
+   *   'site', do not require any explicit information from $data and can be
+   *   replaced even if it is empty.
+   * @param string $type
+   *   For modules which provided pattern items in hook_pathauto(),
+   *   the relevant identifier for the specific item to be aliased
+   *   (e.g., $node->type).
+   * @param string $language
+   *   A string specify the path's language.
+   *
+   * @return array|string
+   *   The alias that was created.
+   *
+   * @see _pathauto_set_alias()
+   */
+  public function createAlias($module, $op, $source, $data, $type = NULL, $language = LanguageInterface::LANGCODE_NOT_SPECIFIED);
+
+  /**
+   * Return an array of arrays for punctuation values.
+   *
+   * Returns an array of arrays for punctuation values keyed by a name, including
+   * the value and a textual description.
+   * Can and should be expanded to include "all" non text punctuation values.
+   *
+   * @return array
+   *   An array of arrays for punctuation values keyed by a name, including the
+   *   value and a textual description.
+   */
+  public function getPunctuationCharacters();
+}

--- a/src/PathautoManagerInterface.php
+++ b/src/PathautoManagerInterface.php
@@ -16,32 +16,32 @@ interface PathautoManagerInterface {
   /**
    * "Do nothing. Leave the old alias intact."
    */
-  const PATHAUTO_UPDATE_ACTION_NO_NEW = 0;
+  const UPDATE_ACTION_NO_NEW = 0;
 
   /**
    * "Create a new alias. Leave the existing alias functioning."
    */
-  const PATHAUTO_UPDATE_ACTION_LEAVE = 1;
+  const UPDATE_ACTION_LEAVE = 1;
 
   /**
    * "Create a new alias. Delete the old alias."
    */
-  const PATHAUTO_UPDATE_ACTION_DELETE = 2;
+  const UPDATE_ACTION_DELETE = 2;
 
   /**
    * Remove the punctuation from the alias.
    */
-  const PATHAUTO_PUNCTUATION_REMOVE = 0;
+  const PUNCTUATION_REMOVE = 0;
 
   /**
    * Replace the punctuation with the separator in the alias.
    */
-  const PATHAUTO_PUNCTUATION_REPLACE = 1;
+  const PUNCTUATION_REPLACE = 1;
 
   /**
    * Leave the punctuation as it is in the alias.
    */
-  const PATHAUTO_PUNCTUATION_DO_NOTHING = 2;
+  const PUNCTUATION_DO_NOTHING = 2;
 
   /**
    * Resets internal caches.

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -193,7 +193,7 @@ class PathautoUnitTest extends KernelTestBase {
     $config = \Drupal::configFactory()->get('pathauto.settings');
 
     // Test PATHAUTO_UPDATE_ACTION_NO_NEW with unaliased node and 'insert'.
-    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW);
+    $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_NO_NEW);
     $config->save();
     $node = $this->drupalCreateNode(array('title' => 'First title'));
     $this->assertEntityAlias($node, 'content/first-title');
@@ -201,7 +201,7 @@ class PathautoUnitTest extends KernelTestBase {
     $node->path->pathauto = TRUE;
 
     // Default action is PATHAUTO_UPDATE_ACTION_DELETE.
-    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE);
+    $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Second title');
     pathauto_entity_update($node);
@@ -209,14 +209,14 @@ class PathautoUnitTest extends KernelTestBase {
     $this->assertNoAliasExists(array('alias' => 'content/first-title'));
 
     // Test PATHAUTO_UPDATE_ACTION_LEAVE
-    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_LEAVE);
+    $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_LEAVE);
     $config->save();
     $node->setTitle('Third title');
     pathauto_entity_update($node);
     $this->assertEntityAlias($node, 'content/third-title');
     $this->assertAliasExists(array('source' => $node->getSystemPath(), 'alias' => 'content/second-title'));
 
-    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE);
+    $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Fourth title');
     pathauto_entity_update($node);
@@ -226,7 +226,7 @@ class PathautoUnitTest extends KernelTestBase {
     $older_path = $this->assertAliasExists(array('source' => $node->getSystemPath(), 'alias' => 'content/second-title'));
     \Drupal::service('path.alias_storage')->delete($older_path);
 
-    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW);
+    $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_NO_NEW);
     $config->save();
     $node->setTitle('Fifth title');
     pathauto_entity_update($node);
@@ -306,7 +306,7 @@ class PathautoUnitTest extends KernelTestBase {
   function testNoExistingPathAliases() {
 
     \Drupal::configFactory()->get('pathauto.settings')
-      ->set('punctuation_period', PathautoManagerInterface::PATHAUTO_PUNCTUATION_DO_NOTHING)
+      ->set('punctuation_period', PathautoManagerInterface::PUNCTUATION_DO_NOTHING)
       ->save();
     \Drupal::configFactory()->get('pathauto.pattern')
       ->set('node.page._default', '[node:title]')

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -9,6 +9,7 @@ namespace Drupal\pathauto\Tests;
 
 use Drupal\Core\Language\Language;
 use Drupal\Component\Utility\String;
+use Drupal\pathauto\PathautoManagerInterface;
 use Drupal\simpletest\KernelTestBase;
 
 /**
@@ -192,7 +193,7 @@ class PathautoUnitTest extends KernelTestBase {
     $config = \Drupal::configFactory()->get('pathauto.settings');
 
     // Test PATHAUTO_UPDATE_ACTION_NO_NEW with unaliased node and 'insert'.
-    $config->set('update_action', PATHAUTO_UPDATE_ACTION_NO_NEW);
+    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW);
     $config->save();
     $node = $this->drupalCreateNode(array('title' => 'First title'));
     $this->assertEntityAlias($node, 'content/first-title');
@@ -200,7 +201,7 @@ class PathautoUnitTest extends KernelTestBase {
     $node->path->pathauto = TRUE;
 
     // Default action is PATHAUTO_UPDATE_ACTION_DELETE.
-    $config->set('update_action', PATHAUTO_UPDATE_ACTION_DELETE);
+    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Second title');
     pathauto_entity_update($node);
@@ -208,14 +209,14 @@ class PathautoUnitTest extends KernelTestBase {
     $this->assertNoAliasExists(array('alias' => 'content/first-title'));
 
     // Test PATHAUTO_UPDATE_ACTION_LEAVE
-    $config->set('update_action', PATHAUTO_UPDATE_ACTION_LEAVE);
+    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_LEAVE);
     $config->save();
     $node->setTitle('Third title');
     pathauto_entity_update($node);
     $this->assertEntityAlias($node, 'content/third-title');
     $this->assertAliasExists(array('source' => $node->getSystemPath(), 'alias' => 'content/second-title'));
 
-    $config->set('update_action', PATHAUTO_UPDATE_ACTION_DELETE);
+    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Fourth title');
     pathauto_entity_update($node);
@@ -225,7 +226,7 @@ class PathautoUnitTest extends KernelTestBase {
     $older_path = $this->assertAliasExists(array('source' => $node->getSystemPath(), 'alias' => 'content/second-title'));
     \Drupal::service('path.alias_storage')->delete($older_path);
 
-    $config->set('update_action', PATHAUTO_UPDATE_ACTION_NO_NEW);
+    $config->set('update_action', PathautoManagerInterface::PATHAUTO_UPDATE_ACTION_NO_NEW);
     $config->save();
     $node->setTitle('Fifth title');
     pathauto_entity_update($node);
@@ -305,7 +306,7 @@ class PathautoUnitTest extends KernelTestBase {
   function testNoExistingPathAliases() {
 
     \Drupal::configFactory()->get('pathauto.settings')
-      ->set('punctuation_period', PATHAUTO_PUNCTUATION_DO_NOTHING)
+      ->set('punctuation_period', PathautoManagerInterface::PATHAUTO_PUNCTUATION_DO_NOTHING)
       ->save();
     \Drupal::configFactory()->get('pathauto.pattern')
       ->set('node.page._default', '[node:title]')


### PR DESCRIPTION
This moves all of the define() contstants in pathauto.inc to a new PathautoManagerInterface.
