### PR TITLE
Prevent PathItem::insert() from running when pathauto will generate the alias

### DIFF
--- a/pathauto.module
+++ b/pathauto.module
@@ -247,6 +247,21 @@ function pathauto_entity_presave($entity) {
 }
 
 /**
+ * Implements hook_entity_insert().
+ */
+function pathauto_entity_insert(EntityInterface $entity) {
+  \Drupal::service('pathauto.manager')->updateAlias($entity, 'insert');
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function pathauto_entity_update(EntityInterface $entity) {
+  \Drupal::service('pathauto.manager')->updateAlias($entity, 'update');
+}
+
+
+/**
  * Update the URL aliases for multiple nodes.
  *
  * @param array $nids

--- a/pathauto.module
+++ b/pathauto.module
@@ -247,27 +247,6 @@ function pathauto_entity_presave($entity) {
 }
 
 /**
- * Implements hook_entity_insert().
- */
-function pathauto_entity_insert(EntityInterface $entity) {
-  \Drupal::service('pathauto.manager')->updateAlias($entity, 'insert');
-}
-
-/**
- * Implements hook_entity_update().
- */
-function pathauto_entity_update(EntityInterface $entity) {
-  \Drupal::service('pathauto.manager')->updateAlias($entity, 'update');
-}
-
-/**
- * Implements hook_entity_delete().
- */
-function pathauto_entity_delete(EntityInterface $entity) {
-  pathauto_entity_path_delete_all($entity);
-}
-
-/**
  * Update the URL aliases for multiple nodes.
  *
  * @param array $nids
@@ -337,6 +316,13 @@ function pathauto_user_update_alias_multiple(array $uids, $op, array $options = 
   if (!empty($options['message'])) {
     drupal_set_message(\Drupal::translation()->formatPlural(count($uids), 'Updated URL alias for 1 user account.', 'Updated URL aliases for @count user accounts.'));
   }
+}
+
+/**
+ * Implements hook_field_info_alter().
+ */
+function pathauto_field_info_alter(&$info) {
+  $info['path']['class'] = '\Drupal\pathauto\PathautoItem';
 }
 
 /**

--- a/src/PathautoItem.php
+++ b/src/PathautoItem.php
@@ -18,11 +18,10 @@ class PathautoItem extends PathItem {
    * {@inheritdoc}
    */
   public function insert() {
+    // Only allow the parent implementation to act if pathauto will not create
+    // an alias.
     if (isset($this->pathauto) && empty($this->pathauto)) {
       parent::insert();
-    }
-    else {
-      \Drupal::service('pathauto.manager')->updateAlias($this->getEntity(), 'insert');
     }
   }
 
@@ -30,11 +29,10 @@ class PathautoItem extends PathItem {
    * {@inheritdoc}
    */
   public function update() {
+    // Only allow the parent implementation to act if pathauto will not create
+    // an alias.
     if (isset($this->pathauto) && empty($this->pathauto)) {
       parent::update();
-    }
-    else {
-      \Drupal::service('pathauto.manager')->updateAlias($this->getEntity(), 'update');
     }
   }
 

--- a/src/PathautoItem.php
+++ b/src/PathautoItem.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\pathauto\PathautoItem.
+ */
+
+namespace Drupal\pathauto;
+
+use Drupal\path\Plugin\Field\FieldType\PathItem;
+
+/**
+ * Extends the default PathItem implementation to generate aliases.
+ */
+class PathautoItem extends PathItem {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function insert() {
+    if (isset($this->pathauto) && empty($this->pathauto)) {
+      parent::insert();
+    }
+    else {
+      \Drupal::service('pathauto.manager')->updateAlias($this->getEntity(), 'insert');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function update() {
+    if (isset($this->pathauto) && empty($this->pathauto)) {
+      parent::update();
+    }
+    else {
+      \Drupal::service('pathauto.manager')->updateAlias($this->getEntity(), 'update');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete() {
+    pathauto_entity_path_delete_all($this->getEntity());
+  }
+
+} 

--- a/src/Tests/PathautoLocaleTest.php
+++ b/src/Tests/PathautoLocaleTest.php
@@ -65,7 +65,7 @@ class PathautoLocaleTest extends WebTestBase {
 
     // Update the node, triggering a change in the English alias.
     $node->path->pathauto = TRUE;
-    pathauto_entity_update($node);
+    $node->save();
 
     // Check that the new English alias replaced the old one.
     $this->assertEntityAlias($node, 'content/english-node-0', 'en');

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -204,7 +204,7 @@ class PathautoUnitTest extends KernelTestBase {
     $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Second title');
-    pathauto_entity_update($node);
+    $node->save();
     $this->assertEntityAlias($node, 'content/second-title');
     $this->assertNoAliasExists(array('alias' => 'content/first-title'));
 
@@ -212,14 +212,14 @@ class PathautoUnitTest extends KernelTestBase {
     $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_LEAVE);
     $config->save();
     $node->setTitle('Third title');
-    pathauto_entity_update($node);
+    $node->save();
     $this->assertEntityAlias($node, 'content/third-title');
     $this->assertAliasExists(array('source' => $node->getSystemPath(), 'alias' => 'content/second-title'));
 
     $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Fourth title');
-    pathauto_entity_update($node);
+    $node->save();
     $this->assertEntityAlias($node, 'content/fourth-title');
     $this->assertNoAliasExists(array('alias' => 'content/third-title'));
     // The older second alias is not deleted yet.
@@ -229,13 +229,13 @@ class PathautoUnitTest extends KernelTestBase {
     $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_NO_NEW);
     $config->save();
     $node->setTitle('Fifth title');
-    pathauto_entity_update($node);
+    $node->save();
     $this->assertEntityAlias($node, 'content/fourth-title');
     $this->assertNoAliasExists(array('alias' => 'content/fifth-title'));
 
     // Test PATHAUTO_UPDATE_ACTION_NO_NEW with unaliased node and 'update'.
     $this->deleteAllAliases();
-    pathauto_entity_update($node);
+    $node->save();
     $this->assertEntityAlias($node, 'content/fifth-title');
 
     // Test PATHAUTO_UPDATE_ACTION_NO_NEW with unaliased node and 'bulkupdate'.
@@ -254,7 +254,7 @@ class PathautoUnitTest extends KernelTestBase {
     $this->assertNoEntityAliasExists($node);
 
     $node->setTitle('hello');
-    pathauto_entity_update($node);
+    $node->save();
     $this->assertEntityAlias($node, 'content/hello');
   }
 
@@ -275,7 +275,7 @@ class PathautoUnitTest extends KernelTestBase {
     $this->assertEntityAlias($term2, 'parent-term/child-term');
 
     $this->saveEntityAlias($term1, 'My Crazy/Alias/');
-    pathauto_entity_update($term2);
+    $term1->save();
     $this->assertEntityAlias($term2, 'My Crazy/Alias/child-term');
   }
 

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -275,7 +275,7 @@ class PathautoUnitTest extends KernelTestBase {
     $this->assertEntityAlias($term2, 'parent-term/child-term');
 
     $this->saveEntityAlias($term1, 'My Crazy/Alias/');
-    $term1->save();
+    $term2->save();
     $this->assertEntityAlias($term2, 'My Crazy/Alias/child-term');
   }
 


### PR DESCRIPTION
I'm not sure yet how much code should be in the pathauto manager, the plugins and this new class, but I think we need this.

Right now, what happens is that both PathItem and our hooks/manager save an alias, this is causing duplicated aliases (see added test). It also caused issues with generation of redirects (but that is already a workaround, so I already added a workaround for the workaround there).
