### PR TITLE
Fatal error when requesting vid and name of vocabularies

### DIFF
--- a/pathauto.pathauto.inc
+++ b/pathauto.pathauto.inc
@@ -145,7 +145,7 @@ function taxonomy_pathauto($op) {
             continue;
           }*/
 
-          $settings['patternitems'][$vocabulary->vid] = t('Pattern for all %vocab-name paths', array('%vocab-name' => $vocabulary->name));
+          $settings['patternitems'][$vocabulary->id()] = t('Pattern for all %vocab-name paths', array('%vocab-name' => $vocabulary->label()));
         }
       }
       return (object) $settings;

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -292,7 +292,7 @@ class PathautoUnitTest extends KernelTestBase {
 
     // Rename the vocabulary's machine name, which should cause its pattern
     // variable to also be renamed.
-    $vocab->vid = 'new_name';
+    $vocab->set('vid', 'new_name');
     $vocab->save();
     $this->assertEntityPattern('taxonomy_term', 'new_name', Language::LANGCODE_NOT_SPECIFIED, 'bundle');
     $this->assertEntityPattern('taxonomy_term', 'old_name', Language::LANGCODE_NOT_SPECIFIED, 'base');


### PR DESCRIPTION
Vid and name are now protected properties. This commit fixes the fatal error by using the getter and setter methods.
