### PR TITLE
Delete aliases does not work

### DIFF
--- a/pathauto.module
+++ b/pathauto.module
@@ -52,7 +52,7 @@ function pathauto_hook_info() {
  * Adds pathauto support for core modules.
  */
 function pathauto_module_implements_alter(&$implementations, $hook) {
-  if (in_array($hook, array('pathauto', 'path_alias_types'))) {
+  if (in_array($hook, array('pathauto'))) {
     $modules = array('node', 'taxonomy', 'user', 'forum');
     foreach ($modules as $module) {
       if (\Drupal::moduleHandler()->moduleExists($module)) {


### PR DESCRIPTION
If I go to /admin/config/search/path/delete_bulk I get the following
error:

...An invalid implementation node_path_alias_types was added by
hook_module_implements_alter()...

There is only one implementation of hook_path_alias_types().
