### PR TITLE
Content translation entity bundle specific settings now use third party settings on language configuration

### DIFF
--- a/pathauto.pathauto.inc
+++ b/pathauto.pathauto.inc
@@ -62,7 +62,7 @@ function node_pathauto($op) {
       }
 
       foreach (node_type_get_names() as $node_type => $node_name) {
-        if (count($languages) && \Drupal::moduleHandler()->moduleExists('content_translation') && content_translation_enabled('node', $node_type)) {
+        if (count($languages) && \Drupal::moduleHandler()->moduleExists('content_translation') && \Drupal::service('content_translation.manager')->isEnabled('node', $node_type)) {
           $settings['patternitems'][$node_type] = t('Default path pattern for @node_type (applies to all @node_type content types with blank patterns below)', array('@node_type' => $node_name));
           foreach ($languages as $lang_code => $lang_name) {
             $settings['patternitems'][$node_type . '_' . $lang_code] = t('Pattern for all @language @node_type paths', array('@node_type' => $node_name, '@language' => $lang_name));

--- a/src/Plugin/pathauto/AliasType/NodeAliasType.php
+++ b/src/Plugin/pathauto/AliasType/NodeAliasType.php
@@ -134,13 +134,13 @@ class NodeAliasType extends AliasTypeBase implements ContainerFactoryPluginInter
    * Wraps content_translation_enabled().
    *
    * @param string $node_type
-   *   the node type.
+   *   The node type.
    *
    * @return bool
-   *   tRUE if content translation is enabled for the content type.
+   *   TRUE if content translation is enabled for the content type.
    */
   protected function isContentTranslationEnabled($node_type) {
-    return $this->moduleHandler->moduleExists('content_translation') && content_translation_enabled('node', $node_type);
+    return $this->moduleHandler->moduleExists('content_translation') && \Drupal::service('content_translation.manager')->isEnabled('node', $node_type);
   }
 
 }


### PR DESCRIPTION
Patch for #28 

Submitted to https://www.drupal.org/node/2168193 for 7.x-1.x
