### PR TITLE
Replaced all old usages of String:: with their new equivalent

### DIFF
--- a/config/schema/pathauto.schema.yml
+++ b/config/schema/pathauto.schema.yml
@@ -4,21 +4,21 @@ pathauto.pattern:
     patterns:
       type: sequence
       sequence:
-        - type: mapping
-          mapping:
-            default:
-              type: string
-            bundles:
-              type: sequence
-              sequence:
-                - type: mapping
-                  mapping:
-                    default:
-                      type: string
-                    languages:
-                      type: sequence
-                      sequence:
-                        - type: string
+        type: mapping
+        mapping:
+          default:
+            type: string
+          bundles:
+            type: sequence
+            sequence:
+              type: mapping
+              mapping:
+                default:
+                  type: string
+                languages:
+                  type: sequence
+                  sequence:
+                    type: string
 
 
 pathauto.settings:
@@ -27,7 +27,7 @@ pathauto.settings:
     punctuation:
       type: sequence
       sequence:
-        - type: integer
+        type: integer
     verbose:
       type: boolean
     separator:

--- a/src/Form/PathautoSettingsForm.php
+++ b/src/Form/PathautoSettingsForm.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\pathauto\Form;
 
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Component\Utility\String;
 use Drupal\pathauto\PathautoManagerInterface;
@@ -159,7 +160,7 @@ class PathautoSettingsForm extends ConfigFormBase {
       }
       $form['punctuation']['punctuation' . $name] = array(
         '#type' => 'select',
-        '#title' => $details['name'] . ' (<code>' . String::checkPlain($details['value']) . '</code>)',
+        '#title' => $details['name'] . ' (<code>' . SafeMarkup::checkPlain($details['value']) . '</code>)',
         '#default_value' => $details['default'],
         '#options' => array(
           PathautoManagerInterface::PUNCTUATION_REMOVE => t('Remove'),

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -7,7 +7,6 @@
 
 namespace Drupal\pathauto;
 
-use Drupal\Component\Utility\String;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -221,7 +220,7 @@ class PathautoManager implements PathautoManagerInterface {
     }
 
     // Remove all HTML tags from the string.
-    $output = strip_tags(String::decodeEntities($string));
+    $output = strip_tags(Html::decodeEntities($string));
 
     // Optionally transliterate.
     if ($this->cleanStringCache['transliterate']) {

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -8,6 +8,7 @@
 namespace Drupal\pathauto;
 
 use Drupal\Component\Utility\Unicode;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\pathauto\Tests;
 
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Language\Language;
 use Drupal\Component\Utility\String;
 use Drupal\pathauto\PathautoManagerInterface;
@@ -134,7 +135,7 @@ class PathautoUnitTest extends KernelTestBase {
 
     // Test that HTML tags are removed.
     $tests['This <span class="text">text</span> has <br /><a href="http://example.com"><strong>HTML tags</strong></a>.'] = 'text-has-html-tags';
-    $tests[String::checkPlain('This <span class="text">text</span> has <br /><a href="http://example.com"><strong>HTML tags</strong></a>.')] = 'text-has-html-tags';
+    $tests[SafeMarkup::checkPlain('This <span class="text">text</span> has <br /><a href="http://example.com"><strong>HTML tags</strong></a>.')] = 'text-has-html-tags';
 
     // Transliteration.
     $tests['ľščťžýáíéňô'] = 'lsctzyaieno';

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -9,7 +9,6 @@ namespace Drupal\pathauto\Tests;
 
 use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Language\Language;
-use Drupal\Component\Utility\String;
 use Drupal\pathauto\PathautoManagerInterface;
 use Drupal\simpletest\KernelTestBase;
 

--- a/src/Tests/PathautoUserWebTest.php
+++ b/src/Tests/PathautoUserWebTest.php
@@ -73,8 +73,10 @@ class PathautoUserWebTest extends WebTestBase {
     $view = Views::getView('user_admin_people');
     $view->initDisplay();
     $view->preview('page_1');
+
+
     foreach ($view->result as $key => $row) {
-      if ($row->users_field_data_name == $account->getUsername()) {
+      if ($view->field['name']->getValue($row) == $account->getUsername()) {
         break;
       }
     }


### PR DESCRIPTION
String::checkPlain -> SafeMarkUp::checkPlain and String::decodeEntitites -> Html::decodeEntities. Removed class declaration at the beginning of files. I did not see any additional classes that had to be replaced. All tests passed.
