### PR TITLE
Path aliases now have a leading /

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ cache:
   apt: true
 
 php:
-  - 5.4
   - 5.5
+  - 5.6
 
 env:
   - PATH=$PATH:/home/travis/.composer/vendor/bin

--- a/config/install/pathauto.pattern.yml
+++ b/config/install/pathauto.pattern.yml
@@ -1,12 +1,12 @@
 patterns:
   node:
-    default: 'content/[node:title]'
+    default: '/content/[node:title]'
 
   taxonomy_term:
-    default: '[term:vocabulary]/[term:name]'
+    default: '/[term:vocabulary]/[term:name]'
 
   forum:
-    default: '[term:vocabulary]/[term:name]'
+    default: '/[term:vocabulary]/[term:name]'
 
   user:
-    default: 'users/[user:name]'
+    default: '/users/[user:name]'

--- a/src/AliasCleaner.php
+++ b/src/AliasCleaner.php
@@ -89,7 +89,7 @@ class AliasCleaner implements AliasCleanerInterface {
 
     if (strlen($separator)) {
       // Trim any leading or trailing separators.
-      $output = trim($output, $separator);
+      $output = rtrim($output, $separator);
 
       // Escape the separator for use in regular expressions.
       $seppattern = preg_quote($separator, '/');

--- a/src/AliasCleaner.php
+++ b/src/AliasCleaner.php
@@ -89,7 +89,7 @@ class AliasCleaner implements AliasCleanerInterface {
 
     if (strlen($separator)) {
       // Trim any leading or trailing separators.
-      $output = rtrim($output, $separator);
+      $output = trim($output, $separator);
 
       // Escape the separator for use in regular expressions.
       $seppattern = preg_quote($separator, '/');
@@ -100,6 +100,11 @@ class AliasCleaner implements AliasCleanerInterface {
       // Replace trailing separators around slashes.
       if ($separator !== '/') {
         $output = preg_replace("/\/+$seppattern\/+|$seppattern\/+|\/+$seppattern/", "/", $output);
+      }
+      else {
+        // If the separator is a slash, we need to re-add the leading slash
+        // dropped by the trim function.
+        $output = '/' . $output;
       }
     }
 

--- a/src/AliasUniquifier.php
+++ b/src/AliasUniquifier.php
@@ -143,7 +143,7 @@ class AliasUniquifier implements AliasUniquifierInterface {
     }
 
     try {
-      $this->urlMatcher->match('/' . $path);
+      $this->urlMatcher->match($path);
       return TRUE;
     }
     catch (ResourceNotFoundException $e) {

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -7,8 +7,8 @@
 
 namespace Drupal\pathauto;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -491,7 +491,7 @@ class PathautoManager implements PathautoManagerInterface {
     }
 
     $result = $this->createAlias(
-      $type, $op, $entity->urlInfo()->getInternalPath(), array($type => $entity), $bundle, $options['language']);
+      $type, $op, '/' . $entity->urlInfo()->getInternalPath(), array($type => $entity), $bundle, $options['language']);
 
     if ($type == 'taxonomy_term' && empty($options['is_child'])) {
       // For all children generate new aliases.

--- a/src/Plugin/Field/FieldWidget/PathautoWidget.php
+++ b/src/Plugin/Field/FieldWidget/PathautoWidget.php
@@ -61,9 +61,9 @@ class PathautoWidget extends PathWidget {
     if (!isset($entity->path->pathauto)) {
       if (!$entity->isNew()) {
         module_load_include('inc', 'pathauto');
-        $path = \Drupal::service('path.alias_manager')->getAliasByPath($entity->urlInfo()->getInternalPath(), $entity->language()->getId());
-        $pathauto_alias = \Drupal::service('pathauto.manager')->createAlias($entity->getEntityTypeId(), 'return', $entity->urlInfo()->getInternalPath(), array($entity->getEntityType()->id() => $entity), $entity->bundle(), $entity->language()->getId());
-        $entity->path->pathauto = ($path != $entity->urlInfo()->getInternalPath() && $path == $pathauto_alias);
+        $path = \Drupal::service('path.alias_manager')->getAliasByPath('/' . $entity->urlInfo()->getInternalPath(), $entity->language()->getId());
+        $pathauto_alias = \Drupal::service('pathauto.manager')->createAlias($entity->getEntityTypeId(), 'return', '/' . $entity->urlInfo()->getInternalPath(), array($entity->getEntityType()->id() => $entity), $entity->bundle(), $entity->language()->getId());
+        $entity->path->pathauto = ($path != '/' . $entity->urlInfo()->getInternalPath() && $path == $pathauto_alias);
       }
       else {
         $entity->path->pathauto = TRUE;

--- a/src/Plugin/pathauto/AliasType/ForumAliasType.php
+++ b/src/Plugin/pathauto/AliasType/ForumAliasType.php
@@ -40,7 +40,7 @@ class ForumAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdate
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array('default' => array('[term:vocabulary]/[term:name]')) + parent::defaultConfiguration();
+    return array('default' => array('/[term:vocabulary]/[term:name]')) + parent::defaultConfiguration();
   }
 
   /**

--- a/src/Plugin/pathauto/AliasType/NodeAliasType.php
+++ b/src/Plugin/pathauto/AliasType/NodeAliasType.php
@@ -33,7 +33,7 @@ class NodeAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdateI
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array('default' => array('content/[node:title]')) + parent::defaultConfiguration();
+    return array('default' => array('/content/[node:title]')) + parent::defaultConfiguration();
   }
 
   /**

--- a/src/Plugin/pathauto/AliasType/TaxonomyTermAliasType.php
+++ b/src/Plugin/pathauto/AliasType/TaxonomyTermAliasType.php
@@ -33,7 +33,7 @@ class TaxonomyTermAliasType extends EntityAliasTypeBase implements AliasTypeBatc
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array('default' => array('[term:vocabulary]/[term:name]')) + parent::defaultConfiguration();
+    return array('default' => array('/[term:vocabulary]/[term:name]')) + parent::defaultConfiguration();
   }
 
   /**

--- a/src/Plugin/pathauto/AliasType/UserAliasType.php
+++ b/src/Plugin/pathauto/AliasType/UserAliasType.php
@@ -33,7 +33,7 @@ class UserAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdateI
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array('default' => array('users/[user:name]')) + parent::defaultConfiguration();
+    return array('default' => array('/users/[user:name]')) + parent::defaultConfiguration();
   }
 
   /**
@@ -46,7 +46,7 @@ class UserAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdateI
     }
 
     $query = db_select('users', 'u');
-    $query->leftJoin('url_alias', 'ua', "CONCAT('user/', u.uid) = ua.source");
+    $query->leftJoin('url_alias', 'ua', "CONCAT('/user/', u.uid) = ua.source");
     $query->addField('u', 'uid');
     $query->isNull('ua.source');
     $query->condition('u.uid', $context['sandbox']['current'], '>');
@@ -84,7 +84,7 @@ class UserAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdateI
    * {@inheritdoc}
    */
   public function getSourcePrefix() {
-    return 'user/';
+    return '/user/';
   }
 
 }

--- a/src/Tests/AliasType/NodeAliasTest.php
+++ b/src/Tests/AliasType/NodeAliasTest.php
@@ -46,7 +46,7 @@ class NodeAliasTest extends KernelTestBase {
     $default_config = $node_type->defaultConfiguration();
 
     $this->assertTrue(array_key_exists('default', $default_config), "Default key exists.");
-    $this->assertEqual($default_config['default'][0], 'content/[node:title]', "Default content pattern matches.");
+    $this->assertEqual($default_config['default'][0], '/content/[node:title]', "Default content pattern matches.");
 
   }
 

--- a/src/Tests/PathautoLocaleTest.php
+++ b/src/Tests/PathautoLocaleTest.php
@@ -47,30 +47,30 @@ class PathautoLocaleTest extends WebTestBase {
       'title' => 'English node',
       'langcode' => 'en',
       'path' => array(array(
-        'alias' => 'english-node',
+        'alias' => '/english-node',
         'pathauto' => FALSE,
       )),
     );
     $node = $this->drupalCreateNode($node);
-    $english_alias = \Drupal::service('path.alias_storage')->load(array('alias' => 'english-node', 'langcode' => 'en'));
+    $english_alias = \Drupal::service('path.alias_storage')->load(array('alias' => '/english-node', 'langcode' => 'en'));
     $this->assertTrue($english_alias, 'Alias created with proper language.');
 
     // Also save a French alias that should not be left alone, even though
     // it is the newer alias.
-    $this->saveEntityAlias($node, 'french-node', 'fr');
+    $this->saveEntityAlias($node, '/french-node', 'fr');
 
     // Add an alias with the soon-to-be generated alias, causing the upcoming
     // alias update to generate a unique alias with the '-0' suffix.
-    $this->saveAlias('node/invalid', 'content/english-node', Language::LANGCODE_NOT_SPECIFIED);
+    $this->saveAlias('/node/invalid', '/content/english-node', Language::LANGCODE_NOT_SPECIFIED);
 
     // Update the node, triggering a change in the English alias.
     $node->path->pathauto = TRUE;
     $node->save();
 
     // Check that the new English alias replaced the old one.
-    $this->assertEntityAlias($node, 'content/english-node-0', 'en');
-    $this->assertEntityAlias($node, 'french-node', 'fr');
-    $this->assertAliasExists(array('pid' => $english_alias['pid'], 'alias' => 'content/english-node-0'));
+    $this->assertEntityAlias($node, '/content/english-node-0', 'en');
+    $this->assertEntityAlias($node, '/french-node', 'fr');
+    $this->assertAliasExists(array('pid' => $english_alias['pid'], 'alias' => '/content/english-node-0'));
   }
 }
 

--- a/src/Tests/PathautoNodeWebTest.php
+++ b/src/Tests/PathautoNodeWebTest.php
@@ -63,7 +63,7 @@ class PathautoNodeWebTest extends WebTestBase {
 
     // Create a node by saving the node form.
     $title = ' Testing: node title [';
-    $automatic_alias = 'content/testing-node-title';
+    $automatic_alias = '/content/testing-node-title';
     $this->drupalPostForm(NULL, array('title[0][value]' => $title), t('Save and publish'));
     $node = $this->drupalGetNodeByTitle($title);
 
@@ -77,7 +77,7 @@ class PathautoNodeWebTest extends WebTestBase {
     $this->assertText($title, 'Node accessible through automatic alias.');
 
     // Manually set the node's alias.
-    $manual_alias = 'content/' . $node->id();
+    $manual_alias = '/content/' . $node->id();
     $edit = array(
       'path[0][pathauto]' => FALSE,
       'path[0][alias]' => $manual_alias,
@@ -107,12 +107,13 @@ class PathautoNodeWebTest extends WebTestBase {
     $edit = array(
       'title[0][value]' => $title,
       'path[0][pathauto]' => TRUE,
-      'path[0][alias]' => 'should-not-get-created',
+      'path[0][alias]' => '/should-not-get-created',
     );
     $this->drupalPostForm('node/add/page', $edit, t('Save and publish'));
     $this->assertNoAliasExists(array('alias' => 'should-not-get-created'));
     $node = $this->drupalGetNodeByTitle($title);
-    $this->assertEntityAlias($node, 'content/automatic-title');
+    debug($node);
+    $this->assertEntityAlias($node, '/content/automatic-title');
 
     // Remove the pattern for nodes, the pathauto checkbox should not be
     // displayed.
@@ -158,8 +159,8 @@ class PathautoNodeWebTest extends WebTestBase {
       '%action' => 'Update URL-Alias',
     )));
 
-    $this->assertEntityAlias($node1, 'content/' . $node1->getTitle());
-    $this->assertEntityAlias($node2, 'node/' . $node2->id());
+    $this->assertEntityAlias($node1, '/content/' . $node1->getTitle());
+    $this->assertEntityAlias($node2, '/node/' . $node2->id());
   }
 
 }

--- a/src/Tests/PathautoNodeWebTest.php
+++ b/src/Tests/PathautoNodeWebTest.php
@@ -112,7 +112,6 @@ class PathautoNodeWebTest extends WebTestBase {
     $this->drupalPostForm('node/add/page', $edit, t('Save and publish'));
     $this->assertNoAliasExists(array('alias' => 'should-not-get-created'));
     $node = $this->drupalGetNodeByTitle($title);
-    debug($node);
     $this->assertEntityAlias($node, '/content/automatic-title');
 
     // Remove the pattern for nodes, the pathauto checkbox should not be

--- a/src/Tests/PathautoTaxonomyWebTest.php
+++ b/src/Tests/PathautoTaxonomyWebTest.php
@@ -61,7 +61,7 @@ class PathautoTaxonomyWebTest extends WebTestBase {
 
     // Create term for testing.
     $name = 'Testing: term name [';
-    $automatic_alias = 'tags/testing-term-name';
+    $automatic_alias = '/tags/testing-term-name';
     $this->drupalPostForm('admin/structure/taxonomy/manage/tags/add', array('name[0][value]' => $name), 'Save');
     $name = trim($name);
     $this->assertText("Created new term $name.");
@@ -77,7 +77,7 @@ class PathautoTaxonomyWebTest extends WebTestBase {
     $this->assertText($name, 'Term accessible through automatic alias.');
 
     // Manually set the term's alias.
-    $manual_alias = 'tags/' . $term->id();
+    $manual_alias = '/tags/' . $term->id();
     $edit = array(
       'path[0][pathauto]' => FALSE,
       'path[0][alias]' => $manual_alias,

--- a/src/Tests/PathautoTestHelperTrait.php
+++ b/src/Tests/PathautoTestHelperTrait.php
@@ -33,7 +33,7 @@ trait PathautoTestHelperTrait {
     if (!$langcode) {
       $langcode = $entity->language()->getId();
     }
-    return $this->saveAlias($entity->urlInfo()->getInternalPath(), $alias, $langcode);
+    return $this->saveAlias('/' . $entity->urlInfo()->getInternalPath(), $alias, $langcode);
   }
 
   public function assertEntityAlias(EntityInterface $entity, $expected_alias, $langcode = NULL) {
@@ -41,11 +41,11 @@ trait PathautoTestHelperTrait {
     if (!$langcode) {
       $langcode = $entity->language()->getId();
     }
-    $this->assertAlias($entity->urlInfo()->getInternalPath(), $expected_alias, $langcode);
+    $this->assertAlias('/' . $entity->urlInfo()->getInternalPath(), $expected_alias, $langcode);
   }
 
   public function assertEntityAliasExists(EntityInterface $entity) {
-    return $this->assertAliasExists(array('source' => $entity->urlInfo()->getInternalPath()));
+    return $this->assertAliasExists(array('source' => '/' . $entity->urlInfo()->getInternalPath()));
   }
 
   public function assertNoEntityAlias(EntityInterface $entity, $langcode = NULL) {
@@ -53,11 +53,11 @@ trait PathautoTestHelperTrait {
     if (!$langcode) {
       $langcode = $entity->language()->getId();
     }
-    $this->assertEntityAlias($entity, $entity->urlInfo()->getInternalPath(), $langcode);
+    $this->assertEntityAlias($entity, '/' . $entity->urlInfo()->getInternalPath(), $langcode);
   }
 
   public function assertNoEntityAliasExists(EntityInterface $entity) {
-    $this->assertNoAliasExists(array('source' => $entity->urlInfo()->getInternalPath()));
+    $this->assertNoAliasExists(array('source' => '/' . $entity->urlInfo()->getInternalPath()));
   }
 
   public function assertAlias($source, $expected_alias, $langcode = Language::LANGCODE_NOT_SPECIFIED) {

--- a/src/Tests/PathautoTokenTest.php
+++ b/src/Tests/PathautoTokenTest.php
@@ -29,7 +29,7 @@ class PathautoTokenTest extends KernelTestBase {
 
     $array = array(
       'test first arg',
-      'the Array / value',
+      'The Array / value',
     );
 
     $tokens = array(

--- a/src/Tests/PathautoTokenTest.php
+++ b/src/Tests/PathautoTokenTest.php
@@ -33,7 +33,7 @@ class PathautoTokenTest extends KernelTestBase {
     );
 
     $tokens = array(
-      'join' => 'test-first-arg/array-value',
+      'join-path' => 'test-first-arg/array-value',
     );
     $data['array'] = $array;
     $replacements = $this->assertTokens('array', $data, $tokens);
@@ -42,7 +42,7 @@ class PathautoTokenTest extends KernelTestBase {
     /* @var \Drupal\pathauto\PathautoManagerInterface $manager */
     $manager = \Drupal::service('pathauto.manager');
     $manager->cleanTokenValues($replacements, $data, array());
-    $this->assertEqual($replacements['[array:join]'], 'test-first-arg/array-value');
+    $this->assertEqual($replacements['[array:join-path]'], 'test-first-arg/array-value');
   }
 
   /**

--- a/src/Tests/PathautoTokenTest.php
+++ b/src/Tests/PathautoTokenTest.php
@@ -29,11 +29,11 @@ class PathautoTokenTest extends KernelTestBase {
 
     $array = array(
       'test first arg',
-      'The Array / value',
+      'the Array / value',
     );
 
     $tokens = array(
-      'join-path' => 'test-first-arg/array-value',
+      'join' => 'test-first-arg/array-value',
     );
     $data['array'] = $array;
     $replacements = $this->assertTokens('array', $data, $tokens);
@@ -42,7 +42,7 @@ class PathautoTokenTest extends KernelTestBase {
     /* @var \Drupal\pathauto\PathautoManagerInterface $manager */
     $manager = \Drupal::service('pathauto.manager');
     $manager->cleanTokenValues($replacements, $data, array());
-    $this->assertEqual($replacements['[array:join-path]'], 'test-first-arg/array-value');
+    $this->assertEqual($replacements['[array:join]'], 'test-first-arg/array-value');
   }
 
   /**

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -154,11 +154,11 @@ class PathautoUnitTest extends KernelTestBase {
    */
   public function testCleanAlias() {
     $tests = array();
-    $tests['one/two/three'] = 'one/two/three';
+    $tests['one/two/three'] = '/one/two/three';
     $tests['/one/two/three/'] = '/one/two/three';
-    $tests['one//two///three'] = 'one/two/three';
-    $tests['one/two--three/-/--/-/--/four---five'] = 'one/two-three/four-five';
-    $tests['one/-//three--/four'] = 'one/three/four';
+    $tests['one//two///three'] = '/one/two/three';
+    $tests['one/two--three/-/--/-/--/four---five'] = '/one/two-three/four-five';
+    $tests['one/-//three--/four'] = '/one/three/four';
 
     foreach ($tests as $input => $expected) {
       $output = \Drupal::service('pathauto.alias_cleaner')->cleanAlias($input);
@@ -214,16 +214,16 @@ class PathautoUnitTest extends KernelTestBase {
     $node->setTitle('Third title');
     $node->save();
     $this->assertEntityAlias($node, '/content/third-title');
-    $this->assertAliasExists(array('source' => '/' . $node->urlInfo()->getInternalPath(), 'alias' => 'content/second-title'));
+    $this->assertAliasExists(array('source' => '/' . $node->urlInfo()->getInternalPath(), 'alias' => '/content/second-title'));
 
     $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_DELETE);
     $config->save();
     $node->setTitle('Fourth title');
     $node->save();
-    $this->assertEntityAlias($node, 'content/fourth-title');
-    $this->assertNoAliasExists(array('alias' => 'content/third-title'));
+    $this->assertEntityAlias($node, '/content/fourth-title');
+    $this->assertNoAliasExists(array('alias' => '/content/third-title'));
     // The older second alias is not deleted yet.
-    $older_path = $this->assertAliasExists(array('source' => $node->urlInfo()->getInternalPath(), 'alias' => '/content/second-title'));
+    $older_path = $this->assertAliasExists(array('source' => '/' . $node->urlInfo()->getInternalPath(), 'alias' => '/content/second-title'));
     \Drupal::service('path.alias_storage')->delete($older_path);
 
     $config->set('update_action', PathautoManagerInterface::UPDATE_ACTION_NO_NEW);
@@ -263,7 +263,7 @@ class PathautoUnitTest extends KernelTestBase {
    */
   public function testPathTokens() {
     $config = $this->config('pathauto.pattern');
-    $config->set('patterns.taxonomy_term.default', '[term:parent:url:path]/[term:name]');
+    $config->set('patterns.taxonomy_term.default', '/[term:parent:url:path]/[term:name]');
     $config->save();
 
     $vocab = $this->addVocabulary();
@@ -315,23 +315,23 @@ class PathautoUnitTest extends KernelTestBase {
 
     // Check that Pathauto does not create an alias of '/admin'.
     $node = $this->drupalCreateNode(array('title' => 'Admin', 'type' => 'page'));
-    $this->assertEntityAlias($node, 'admin-0');
+    $this->assertEntityAlias($node, '/admin-0');
 
     // Check that Pathauto does not create an alias of '/modules'.
     $node->setTitle('Modules');
     $node->save();
-    $this->assertEntityAlias($node, 'modules-0');
+    $this->assertEntityAlias($node, '/modules-0');
 
     // Check that Pathauto does not create an alias of '/index.php'.
     $node->setTitle('index.php');
     $node->save();
-    $this->assertEntityAlias($node, 'index.php-0');
+    $this->assertEntityAlias($node, '/index.php-0');
 
     // Check that a safe value gets an automatic alias. This is also a control
     // to ensure the above tests work properly.
     $node->setTitle('Safe value');
     $node->save();
-    $this->assertEntityAlias($node, 'safe-value');
+    $this->assertEntityAlias($node, '/safe-value');
   }
 
   /**

--- a/src/Tests/PathautoUserWebTest.php
+++ b/src/Tests/PathautoUserWebTest.php
@@ -90,8 +90,8 @@ class PathautoUserWebTest extends WebTestBase {
       '%action' => 'Update URL-Alias',
     )));
 
-    $this->assertEntityAlias($account, 'users/' . Unicode::strtolower($account->getUsername()));
-    $this->assertEntityAlias($this->adminUser, 'user/' . $this->adminUser->id());
+    $this->assertEntityAlias($account, '/users/' . Unicode::strtolower($account->getUsername()));
+    $this->assertEntityAlias($this->adminUser, '/user/' . $this->adminUser->id());
   }
 
 }


### PR DESCRIPTION
Restart of #45.

Relevant changes:
- reverted join-path: I think @LKS90 had an unrelated change in token that was also wrong that confused him. Test works just fine without changes.
- Removed the leading / from match(). That caused a fun recursion. 
- Reverted the trim and enforced a leading / as suggested by @DuaelFr
- Fixed a bunch of tests that weren't using leading / correctly yet.
