### PR TITLE
Use alias storage, explicitly handle an alias that points to the give…

### DIFF
--- a/pathauto.services.yml
+++ b/pathauto.services.yml
@@ -10,7 +10,7 @@ services:
     arguments: ['@config.factory', '@path.alias_storage', '@database','@pathauto.verbose_messenger', '@string_translation']
   pathauto.alias_uniquifier:
     class: Drupal\pathauto\AliasUniquifier
-    arguments: ['@config.factory', '@pathauto.alias_storage_helper','@module_handler', '@router.no_access_checks']
+    arguments: ['@config.factory', '@module_handler', '@router.no_access_checks', '@path.alias_manager']
   pathauto.verbose_messenger:
     class: Drupal\pathauto\VerboseMessenger
     arguments: ['@config.factory', '@current_user']

--- a/pathauto.services.yml
+++ b/pathauto.services.yml
@@ -10,7 +10,7 @@ services:
     arguments: ['@config.factory', '@path.alias_storage', '@database','@pathauto.verbose_messenger', '@string_translation']
   pathauto.alias_uniquifier:
     class: Drupal\pathauto\AliasUniquifier
-    arguments: ['@config.factory', '@module_handler', '@router.no_access_checks', '@path.alias_manager']
+    arguments: ['@config.factory', '@pathauto.alias_storage_helper','@module_handler', '@router.no_access_checks', '@path.alias_manager']
   pathauto.verbose_messenger:
     class: Drupal\pathauto\VerboseMessenger
     arguments: ['@config.factory', '@current_user']

--- a/src/AliasUniquifier.php
+++ b/src/AliasUniquifier.php
@@ -29,6 +29,13 @@ class AliasUniquifier implements AliasUniquifierInterface {
   protected $configFactory;
 
   /**
+   * The alias storage helper.
+   *
+   * @var \Drupal\pathauto\AliasStorageHelperInterface
+   */
+  protected $aliasStorageHelper;
+
+  /**
    * The module handler.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface
@@ -54,13 +61,16 @@ class AliasUniquifier implements AliasUniquifierInterface {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\pathauto\AliasStorageHelperInterface $alias_storage_helper
+   *   The alias storage helper.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
    * @param \Symfony\Component\Routing\Matcher\UrlMatcherInterface $url_matcher
    *   The url matcher service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler, UrlMatcherInterface $url_matcher, AliasManagerInterface $alias_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, AliasStorageHelperInterface $alias_storage_helper, ModuleHandlerInterface $module_handler, UrlMatcherInterface $url_matcher, AliasManagerInterface $alias_manager) {
     $this->configFactory = $config_factory;
+    $this->aliasStorageHelper = $alias_storage_helper;
     $this->moduleHandler = $module_handler;
     $this->urlMatcher = $url_matcher;
     $this->aliasManager = $alias_manager;

--- a/src/AliasUniquifier.php
+++ b/src/AliasUniquifier.php
@@ -106,9 +106,12 @@ class AliasUniquifier implements AliasUniquifierInterface {
   public function isReserved($alias, $source, $langcode = LanguageInterface::LANGCODE_NOT_SPECIFIED) {
     // Check if this alias already exists.
     if ($existing_source = $this->aliasManager->getPathByAlias($alias, $langcode)) {
-      // If it is an alias for the provided source, it is allowed to keep using
-      // it. If not, then it is reserved.
-      return $existing_source != $source;
+      if ($existing_source != $alias) {
+        // If it is an alias for the provided source, it is allowed to keep using
+        // it. If not, then it is reserved.
+        return $existing_source != $source;
+      }
+
     }
 
     // Then check if there is a route with the same path.


### PR DESCRIPTION
Path matching now automatically does inbound path processing. That means we can't use it anymore like we used to since it will match our own alias too.

Not 100% sure yet, but I think we can fix it by always explicitly checking for an alias. If it is exists, and is the same, then we can continue using it (not reserved).

This fixes #47.
