### PR TITLE
Return empty metadata when calling Token::replace().

### DIFF
--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -367,6 +367,8 @@ class PathautoManager implements PathautoManagerInterface {
 
     // Replace any tokens in the pattern.
     // Uses callback option to clean replacements. No sanitization.
+    // Pass empty BubbleableMetadata object to explicitly ignore cacheablity,
+    // as the result is never rendered.
     $alias = $this->token->replace($pattern, $data, array(
       'sanitize' => FALSE,
       'clear' => TRUE,

--- a/src/PathautoManager.php
+++ b/src/PathautoManager.php
@@ -16,6 +16,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Utility\Token;
@@ -372,7 +373,7 @@ class PathautoManager implements PathautoManagerInterface {
       'callback' => array($this, 'cleanTokenValues'),
       'langcode' => $langcode,
       'pathauto' => TRUE,
-    ));
+    ), new BubbleableMetadata());
 
     // Check if the token replacement has not actually replaced any values. If
     // that is the case, then stop because we should not generate an alias.


### PR DESCRIPTION
This addresses a bug discussed in #64, where cacheable empty responses coming from REST would result in a 500 error.
