### PR TITLE
Make PathautoPatternsForm::buildForm() account for missing config

### DIFF
--- a/src/Form/PathautoPatternsForm.php
+++ b/src/Form/PathautoPatternsForm.php
@@ -71,7 +71,8 @@ class PathautoPatternsForm extends ConfigFormBase {
 
     foreach ($definitions as $id => $definition) {
       /** @var \Drupal\pathauto\AliasTypeInterface $alias_type */
-      $alias_type = $this->aliasTypeManager->createInstance($id, $config->get('patterns.' . $id));
+      $alias_type = $this->aliasTypeManager->createInstance($id);
+      $alias_type->setConfiguration($config->get('patterns.' . $id) ?: []);
 
       $form[$id] = $alias_type->buildConfigurationForm([], $form_state);
     }

--- a/src/Form/PathautoPatternsForm.php
+++ b/src/Form/PathautoPatternsForm.php
@@ -71,8 +71,7 @@ class PathautoPatternsForm extends ConfigFormBase {
 
     foreach ($definitions as $id => $definition) {
       /** @var \Drupal\pathauto\AliasTypeInterface $alias_type */
-      $alias_type = $this->aliasTypeManager->createInstance($id);
-      $alias_type->setConfiguration($config->get('patterns.' . $id) ?: []);
+      $alias_type = $this->aliasTypeManager->createInstance($id, $config->get('patterns.' . $id) ?: []);
 
       $form[$id] = $alias_type->buildConfigurationForm([], $form_state);
     }

--- a/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
+++ b/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
@@ -63,6 +63,7 @@ abstract class EntityAliasTypeBase extends PluginBase implements AliasTypeInterf
     $this->moduleHandler = $module_handler;
     $this->languageManager = $language_manager;
     $this->entityManager = $entity_manager;
+    $this->setConfiguration($configuration);
   }
 
   /**


### PR DESCRIPTION
The default pattern config shipped with the module cannot account for alias
types provided by other modules (e.g. File Entity). We cannot use the ternary in
createInstance() directly and instead need to call setConfiguration() because
the defaultConfiguration() would be ignored otherwise.
