### PR TITLE
Replace checkPlain() function and added html entities decode

### DIFF
--- a/src/AliasCleaner.php
+++ b/src/AliasCleaner.php
@@ -9,6 +9,7 @@ namespace Drupal\pathauto;
 
 use Drupal\Component\Render\PlainTextOutput;
 use Drupal\Component\Transliteration\TransliterationInterface;
+use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -229,7 +230,8 @@ class AliasCleaner implements AliasCleanerInterface {
     }
 
     // Remove all HTML tags from the string.
-    $output = PlainTextOutput::renderFromHtml($string);
+    $output = Html::decodeEntities($string);
+    $output = PlainTextOutput::renderFromHtml($output);
 
     // Optionally transliterate.
     if ($this->cleanStringCache['transliterate']) {

--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\pathauto\Tests;
 
-use Drupal\Component\Utility\SafeMarkup;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Language\Language;
 use Drupal\node\Entity\NodeType;
 use Drupal\pathauto\PathautoManagerInterface;
@@ -139,7 +139,7 @@ class PathautoUnitTest extends KernelTestBase {
 
     // Test that HTML tags are removed.
     $tests['This <span class="text">text</span> has <br /><a href="http://example.com"><strong>HTML tags</strong></a>.'] = 'text-has-html-tags';
-    $tests[(string) SafeMarkup::checkPlain('This <span class="text">text</span> has <br /><a href="http://example.com"><strong>HTML tags</strong></a>.')] = 'text-has-html-tags';
+    $tests[Html::escape('This <span class="text">text</span> has <br /><a href="http://example.com"><strong>HTML tags</strong></a>.')] = 'text-has-html-tags';
 
     // Transliteration.
     $tests['ľščťžýáíéňô'] = 'lsctzyaieno';


### PR DESCRIPTION
Test was failing because 
**Value span-class-text-text-span-has-br-a is equal to value text-has-html-tags.**
So  for the text here 
`(string) SafeMarkup::checkPlain('This <span class="text">text</span>`...

 in `PlainTextOutput::renderFromHtml($output);`
 instead of removing the html tags was just removing html entities generated from `checkPlain();`
`'This &lt;span class=&quot;text&quot;&gt;text&lt;/`

So then we still have the words(span, class, etc) in the output. 
I am not sure if is the way to fix that, decoding first and then removing the html tags.
