### PR TITLE
Update the source prefix for the forum, node and taxonomy term alias types.

### DIFF
--- a/src/Plugin/pathauto/AliasType/ForumAliasType.php
+++ b/src/Plugin/pathauto/AliasType/ForumAliasType.php
@@ -54,7 +54,7 @@ class ForumAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdate
    * {@inheritdoc}
    */
   public function getSourcePrefix() {
-    return 'forum/';
+    return '/forum/';
   }
 
 }

--- a/src/Plugin/pathauto/AliasType/NodeAliasType.php
+++ b/src/Plugin/pathauto/AliasType/NodeAliasType.php
@@ -40,7 +40,7 @@ class NodeAliasType extends EntityAliasTypeBase implements AliasTypeBatchUpdateI
    * {@inheritdoc}
    */
   public function getSourcePrefix() {
-    return 'node/';
+    return '/node/';
   }
 
 }

--- a/src/Plugin/pathauto/AliasType/TaxonomyTermAliasType.php
+++ b/src/Plugin/pathauto/AliasType/TaxonomyTermAliasType.php
@@ -40,7 +40,7 @@ class TaxonomyTermAliasType extends EntityAliasTypeBase implements AliasTypeBatc
    * {@inheritdoc}
    */
   public function getSourcePrefix() {
-    return 'taxonomy/term/';
+    return '/taxonomy/term/';
   }
 
 }


### PR DESCRIPTION
The source prefixes were wrong for these entity types (for users it was correct). As a result, the content aliases could not be bulk deleted for example.
