### PR TITLE
Fix form redirection after bulk delete

### DIFF
--- a/src/Form/PathautoAdminDelete.php
+++ b/src/Form/PathautoAdminDelete.php
@@ -111,7 +111,7 @@ class PathautoAdminDelete extends FormBase {
         ->execute();
       drupal_set_message(t('All of your %label path aliases have been deleted.', array('%label' => $alias_type->getLabel())));
     }
-    $form_state->setRedirect('pathauto.bulk.update.form');
+    $form_state->setRedirect('pathauto.admin.delete');
   }
 
 }

--- a/src/Form/PathautoSettingsForm.php
+++ b/src/Form/PathautoSettingsForm.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\pathauto\Form\MaillogSettingsForm.
+ * Contains \Drupal\pathauto\Form\PathautoSettingsForm.
  */
 
 namespace Drupal\pathauto\Form;

--- a/src/Tests/PathautoMassDeleteTest.php
+++ b/src/Tests/PathautoMassDeleteTest.php
@@ -84,6 +84,7 @@ class PathautoMassDeleteTest extends WebTestBase {
     );
     $this->drupalPostForm('admin/config/search/path/delete_bulk', $edit, t('Delete aliases now!'));
     $this->assertText(t('All of your path aliases have been deleted.'));
+    $this->assertUrl(\Drupal::url('pathauto.admin.delete'));
 
     // Make sure that all of them are actually deleted.
     $aliases = db_select('url_alias', 'ua')->fields('ua', array())->execute()->fetchAll();


### PR DESCRIPTION
The Bulk Delete form redirects to the Bulk Update form after performing the deletion. This pull request fixes it.
