### PR TITLE
Use the appropriate theme call to render link to show token tree

### DIFF
--- a/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
+++ b/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
@@ -168,9 +168,8 @@ abstract class EntityAliasTypeBase extends PluginBase implements AliasTypeInterf
 
     // Show the token help relevant to this pattern type.
     $form['token_help'] = array(
-      '#theme' => 'token_tree',
+      '#theme' => 'token_tree_link',
       '#token_types' => $this->getTokenTypes(),
-      '#dialog' => TRUE,
     );
     return $form;
   }


### PR DESCRIPTION
The dialog option for token browser is not used and is going to be
removed in https://www.drupal.org/node/2640138. This commit changes the
usages to the correct and more appropriate theme function.
