### PR TITLE
Fix failing assertion on PathautoUnitTest

### DIFF
--- a/src/Tests/PathautoUnitTest.php
+++ b/src/Tests/PathautoUnitTest.php
@@ -146,7 +146,7 @@ class PathautoUnitTest extends KernelTestBase {
           'title' => 'Page',
           'type' => 'page',
         ],
-        'expected' => '/[node:title]',
+        'expected' => '/content/[node:title]',
       ),
       array(
         'entity' => 'user',


### PR DESCRIPTION
The assertion fails because there is a global pattern that starts with
content, which is created at setUp().

This is the failure when we run the PathautoUnitTest test:

![selection_005](https://cloud.githubusercontent.com/assets/108130/12007449/300b82ea-ac05-11e5-93c0-e3a788a3e9e2.png)
