### PR TITLE
[#10] Port patterns from config objects to config entities

### DIFF
--- a/pathauto.install
+++ b/pathauto.install
@@ -9,6 +9,9 @@
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Utility\UpdateException;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\pathauto\Entity\PathautoPattern;
 
 /**
  * Implements hook_install().
@@ -65,7 +68,7 @@ function pathauto_update_8100(&$sandbox) {
   $entity_manager = \Drupal::service('entity.manager');
   $entity_type_manager = \Drupal::service('entity_type.manager');
   $language_manager = \Drupal::service('language_manager');
-  $entity_info = $entity_manager->getDefinitions();
+  $entity_types = $entity_manager->getDefinitions();
 
   // 1. Load all patterns.
   $config = \Drupal::service('config.factory')->getEditable('pathauto.pattern');
@@ -73,7 +76,7 @@ function pathauto_update_8100(&$sandbox) {
 
   // 2. Create a configuration entity per pattern.
   foreach ($patterns as $entity_type => $entity_patterns) {
-    if (!array_key_exists($entity_type, $entity_info)) {
+    if (!array_key_exists($entity_type, $entity_types)) {
       // We found an unknown entity type. Report it.
       $messages[] = t('Entity of type @type was not processed. It defines the following patterns: @patterns', array(
         '@type' => $entity_type,
@@ -81,18 +84,18 @@ function pathauto_update_8100(&$sandbox) {
       ));
       continue;
     }
-    $entity_label = $entity_info[$entity_type]->getLabel();
+    $entity_label = $entity_types[$entity_type]->getLabel();
 
     if (isset($entity_patterns['default'])) {
       // This is a pattern for an entity type, such as "node".
-      $entity = entity_create('pathauto_pattern', [
+      $pattern = PathautoPattern::create([
         'id' => $entity_type,
         'label' => $entity_label,
         'type' => 'canonical_entities:' . $entity_type,
         'pattern' => $entity_patterns['default'],
         'weight' => 0,
       ]);
-      $entity->save();
+      $pattern->save();
     }
 
     // Loop over bundles and create patterns if they have a value.
@@ -107,7 +110,7 @@ function pathauto_update_8100(&$sandbox) {
 
         if (isset($bundle_info[$bundle])) {
           // This is a pattern for a bundle, such as "node_article".
-          $entity = entity_create('pathauto_pattern', [
+          $pattern = PathautoPattern::create([
             'id' => $entity_type . '_' . $bundle,
             'label' => $entity_label . ' ' . $bundle_info[$bundle]['label'],
             'type' => 'canonical_entities:' . $entity_type,
@@ -116,14 +119,14 @@ function pathauto_update_8100(&$sandbox) {
           ]);
 
           // Add the bundle condition.
-          $entity->addSelectionCondition([
+          $pattern->addSelectionCondition([
             'id' => 'entity_bundle:' . $entity_type,
             'bundles' => array($bundle),
             'negate' => FALSE,
             'context_mapping' => [ $entity_type => $entity_type ],
           ]);
 
-          $entity->save();
+          $pattern->save();
         }
         else {
           // This is either a language dependent pattern such as "article_es" or
@@ -146,8 +149,8 @@ function pathauto_update_8100(&$sandbox) {
           }
 
           // This is a pattern for a bundle and a language, such as "node_article_es".
-          $entity = entity_create('pathauto_pattern', [
-            'id' => $entity_type . '_' . $extracted_bundle . '_' . $langcode,
+          $pattern = PathautoPattern::create([
+            'id' => $entity_type . '_' . $extracted_bundle . '_' . str_replace('-', '_', $langcode),
             'label' => $entity_label . ' ' . $bundle_info[$extracted_bundle]['label'] . ' ' . $language->getName(),
             'type' => 'canonical_entities:' . $entity_type,
             'pattern' => $bundle_patterns['default'],
@@ -155,30 +158,36 @@ function pathauto_update_8100(&$sandbox) {
           ]);
 
           // Add the bundle condition.
-          $entity->addSelectionCondition([
+          $pattern->addSelectionCondition([
             'id' => 'entity_bundle:' . $entity_type,
-            'bundles' => array($extracted_bundle),
+            'bundles' => array($extracted_bundle => $extracted_bundle),
             'negate' => FALSE,
             'context_mapping' => [ $entity_type => $entity_type ],
           ]);
 
           // Add the language condition.
-          $entity->addSelectionCondition([
+          $language_mapping = $entity_type . ':' . $entity_type_manager->getDefinition($entity_type)->getKey('langcode') . ':language';
+          $pattern->addSelectionCondition([
             'id' => 'language',
             'langcodes' => [ $langcode => $langcode ],
             'negate' => FALSE,
             'context_mapping' => [
-              'language' => $entity_type . ':' . $entity_type_manager->getDefinition($entity_type)->getKey('langcode') . ':language',
+              'language' => $language_mapping,
             ]
           ]);
 
-          $entity->save();
+          // Add the context relationship for this language.
+          $new_definition = new ContextDefinition('language', 'Language');
+          $new_context = new Context($new_definition);
+          $pattern->addContext($language_mapping, $new_context);
+
+          $pattern->save();
         }
       }
     }
   }
 
-  // 3. Delete the old configuration object that stores patterns only if all
+  // 3. Delete the old configuration object that stores patterns.
   $config->delete();
 
   // 4. Print out messages.

--- a/pathauto.install
+++ b/pathauto.install
@@ -8,6 +8,7 @@
  */
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Utility\UpdateException;
 
 /**
  * Implements hook_install().
@@ -49,5 +50,103 @@ function pathauto_update_8001() {
         $form_display->save();
       }
     }
+  }
+}
+
+/**
+ * Converts patterns from configuration objects to configuration entities.
+ */
+function pathauto_update_8100(&$sandbox) {
+  $messages = array();
+  $delete_config = TRUE;
+
+  if (!\Drupal::service('module_handler')->moduleExists('ctools')) {
+    throw new UpdateException('Please, install Chaos tools suite (https://www.drupal.org/project/ctools) before running this databsae update.');
+  }
+
+  $entity_manager = \Drupal::service('entity.manager');
+  $entity_info = $entity_manager->getDefinitions();
+
+  // 1. Load all patterns.
+  $config = \Drupal::service('config.factory')->getEditable('pathauto.pattern');
+  $patterns = $config->get('patterns');
+
+  // 2. Create a configuration entity per pattern.
+  foreach ($patterns as $entity_type => $pattern_config) {
+    if (!array_key_exists($entity_type, $entity_info)) {
+      // We found an entity type which we don't know how to process. Report it.
+      $messages[] = t('Entity of type @type was not processed.', array('@type' => $entity_type));
+      $delete_config = FALSE;
+      continue;
+    }
+    $entity_label = (string) $entity_info[$entity_type]->get('label');
+    // Create and save the default pattern for this entity.
+    if (isset($pattern_config['default'])) {
+      // Check if the administrator created this pattern before running updates.
+      // If there is a pattern, skip to the next one.
+      $entity = entity_load('pathauto_pattern', $entity_type);
+      if ($entity) {
+        continue;
+      }
+      // There is no default pattern. Create and save.
+      $entity = entity_create('pathauto_pattern', [
+        'id' => $entity_type,
+        'label' => $entity_label,
+        'type' => 'canonical_entities:' . $entity_type,
+        'pattern' => $pattern_config['default'],
+        'weight' => 0,
+      ]);
+      $entity->save();
+    }
+    // Loop over bundles and create patterns if they override the default
+    // pattern.
+    if (isset($pattern_config['bundles'])) {
+      foreach ($pattern_config['bundles'] as $bundle => $bundle_config) {
+        if (!empty($bundle_config['default'])) {
+          $id = $entity_type . '_' . $bundle;
+          // Check if the administrator created this pattern before running updates.
+          // If there is a pattern, skip to the next one.
+          $entity = entity_load('pathauto_pattern', $id);
+          if ($entity) {
+            continue;
+          }
+
+          // Figure out the label of this pattern.
+          $bundle_info = $entity_manager->getBundleInfo($entity_type);
+          $bundle_label = $bundle_info[$bundle]['label'];
+          $label = $entity_label . ' ' . $bundle_label;
+
+          // Create and save the pattern for this entity bundle.
+          $entity = entity_create('pathauto_pattern', [
+            'id' => $id,
+            'label' => $label,
+            'type' => 'canonical_entities:' . $entity_type,
+            'pattern' => $bundle_config['default'],
+            'weight' => -5,
+          ]);
+
+          // Add the bundle condition.
+          $entity->addSelectionCondition([
+            'id' => 'entity_bundle:' . $entity_type,
+            'bundles' => array($bundle),
+            'negate' => FALSE,
+            'context_mapping' => [
+              $entity_type => $entity_type,
+            ],
+          ]);
+
+          $entity->save();
+        }
+      }
+    }
+  }
+
+  // 3. Delete the old configuration object that stores patterns only if all
+  // configuration objects were processed.
+  if ($delete_config) {
+    $config->delete();
+  }
+  if (!empty($messages)) {
+    return implode('</br>', $messages);
   }
 }

--- a/pathauto.install
+++ b/pathauto.install
@@ -57,14 +57,14 @@ function pathauto_update_8001() {
  * Converts patterns from configuration objects to configuration entities.
  */
 function pathauto_update_8100(&$sandbox) {
-  $messages = array();
-  $delete_config = TRUE;
-
   if (!\Drupal::service('module_handler')->moduleExists('ctools')) {
-    throw new UpdateException('Please, install Chaos tools suite (https://www.drupal.org/project/ctools) before running this databsae update.');
+    throw new UpdateException('Install Chaos tools suite (https://www.drupal.org/project/ctools) before running this database update.');
   }
 
+  $messages = array();
   $entity_manager = \Drupal::service('entity.manager');
+  $entity_type_manager = \Drupal::service('entity_type.manager');
+  $language_manager = \Drupal::service('language_manager');
   $entity_info = $entity_manager->getDefinitions();
 
   // 1. Load all patterns.
@@ -72,56 +72,46 @@ function pathauto_update_8100(&$sandbox) {
   $patterns = $config->get('patterns');
 
   // 2. Create a configuration entity per pattern.
-  foreach ($patterns as $entity_type => $pattern_config) {
+  foreach ($patterns as $entity_type => $entity_patterns) {
     if (!array_key_exists($entity_type, $entity_info)) {
-      // We found an entity type which we don't know how to process. Report it.
-      $messages[] = t('Entity of type @type was not processed.', array('@type' => $entity_type));
-      $delete_config = FALSE;
+      // We found an unknown entity type. Report it.
+      $messages[] = t('Entity of type @type was not processed. It defines the following patterns: @patterns', array(
+        '@type' => $entity_type,
+        '@patterns' => print_r($entity_patterns, TRUE),
+      ));
       continue;
     }
-    $entity_label = (string) $entity_info[$entity_type]->get('label');
-    // Create and save the default pattern for this entity.
-    if (isset($pattern_config['default'])) {
-      // Check if the administrator created this pattern before running updates.
-      // If there is a pattern, skip to the next one.
-      $entity = entity_load('pathauto_pattern', $entity_type);
-      if ($entity) {
-        continue;
-      }
-      // There is no default pattern. Create and save.
+    $entity_label = $entity_info[$entity_type]->getLabel();
+
+    if (isset($entity_patterns['default'])) {
+      // This is a pattern for an entity type, such as "node".
       $entity = entity_create('pathauto_pattern', [
         'id' => $entity_type,
         'label' => $entity_label,
         'type' => 'canonical_entities:' . $entity_type,
-        'pattern' => $pattern_config['default'],
+        'pattern' => $entity_patterns['default'],
         'weight' => 0,
       ]);
       $entity->save();
     }
-    // Loop over bundles and create patterns if they override the default
-    // pattern.
-    if (isset($pattern_config['bundles'])) {
-      foreach ($pattern_config['bundles'] as $bundle => $bundle_config) {
-        if (!empty($bundle_config['default'])) {
-          $id = $entity_type . '_' . $bundle;
-          // Check if the administrator created this pattern before running updates.
-          // If there is a pattern, skip to the next one.
-          $entity = entity_load('pathauto_pattern', $id);
-          if ($entity) {
-            continue;
-          }
 
-          // Figure out the label of this pattern.
-          $bundle_info = $entity_manager->getBundleInfo($entity_type);
-          $bundle_label = $bundle_info[$bundle]['label'];
-          $label = $entity_label . ' ' . $bundle_label;
+    // Loop over bundles and create patterns if they have a value.
+    // Bundle keys may have a language suffix for language-dependant patterns.
+    if (isset($entity_patterns['bundles'])) {
+      $bundle_info = $entity_manager->getBundleInfo($entity_type);
+      foreach ($entity_patterns['bundles'] as $bundle => $bundle_patterns) {
+        if (empty($bundle_patterns['default'])) {
+          // This bundle does not define a pattern. Move on to the next one.
+          continue;
+        }
 
-          // Create and save the pattern for this entity bundle.
+        if (isset($bundle_info[$bundle])) {
+          // This is a pattern for a bundle, such as "node_article".
           $entity = entity_create('pathauto_pattern', [
-            'id' => $id,
-            'label' => $label,
+            'id' => $entity_type . '_' . $bundle,
+            'label' => $entity_label . ' ' . $bundle_info[$bundle]['label'],
             'type' => 'canonical_entities:' . $entity_type,
-            'pattern' => $bundle_config['default'],
+            'pattern' => $bundle_patterns['default'],
             'weight' => -5,
           ]);
 
@@ -130,9 +120,56 @@ function pathauto_update_8100(&$sandbox) {
             'id' => 'entity_bundle:' . $entity_type,
             'bundles' => array($bundle),
             'negate' => FALSE,
+            'context_mapping' => [ $entity_type => $entity_type ],
+          ]);
+
+          $entity->save();
+        }
+        else {
+          // This is either a language dependent pattern such as "article_es" or
+          // an unknown bundle or langcode. Let's figure it out.
+          $matches = NULL;
+          $langcode = NULL;
+          preg_match('/^(.*)_([a-z-]*)$/', $bundle, $matches);
+          if (count($matches) == 3) {
+            list(, $extracted_bundle, $langcode) = $matches;
+            $language = $language_manager->getLanguage($langcode);
+          }
+          // Validate bundle, langcode and language.
+          if (!isset($bundle_info[$extracted_bundle]) || ($langcode == NULL) || ($language == NULL)) {
+            $messages[] = t('Unrecognized entity bundle @entity:@bundle was not processed. It defines the following patterns: @patterns', array(
+              '@entity' => $entity_type,
+              '@bundle' => $bundle,
+              '@patterns' => print_r($entity_patterns, TRUE),
+            ));
+            continue;
+          }
+
+          // This is a pattern for a bundle and a language, such as "node_article_es".
+          $entity = entity_create('pathauto_pattern', [
+            'id' => $entity_type . '_' . $extracted_bundle . '_' . $langcode,
+            'label' => $entity_label . ' ' . $bundle_info[$extracted_bundle]['label'] . ' ' . $language->getName(),
+            'type' => 'canonical_entities:' . $entity_type,
+            'pattern' => $bundle_patterns['default'],
+            'weight' => -10,
+          ]);
+
+          // Add the bundle condition.
+          $entity->addSelectionCondition([
+            'id' => 'entity_bundle:' . $entity_type,
+            'bundles' => array($extracted_bundle),
+            'negate' => FALSE,
+            'context_mapping' => [ $entity_type => $entity_type ],
+          ]);
+
+          // Add the language condition.
+          $entity->addSelectionCondition([
+            'id' => 'language',
+            'langcodes' => [ $langcode => $langcode ],
+            'negate' => FALSE,
             'context_mapping' => [
-              $entity_type => $entity_type,
-            ],
+              'language' => $entity_type . ':' . $entity_type_manager->getDefinition($entity_type)->getKey('langcode') . ':language',
+            ]
           ]);
 
           $entity->save();
@@ -142,10 +179,9 @@ function pathauto_update_8100(&$sandbox) {
   }
 
   // 3. Delete the old configuration object that stores patterns only if all
-  // configuration objects were processed.
-  if ($delete_config) {
-    $config->delete();
-  }
+  $config->delete();
+
+  // 4. Print out messages.
   if (!empty($messages)) {
     return implode('</br>', $messages);
   }

--- a/src/Form/PatternEditForm.php
+++ b/src/Form/PatternEditForm.php
@@ -12,6 +12,8 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\pathauto\AliasTypeManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -231,16 +233,20 @@ class PatternEditForm extends EntityForm {
 
       if ($languages = array_filter((array) $form_state->getValue('languages'))) {
         $default_weight -= 5;
+        $language_mapping = $entity_type . ':' . $this->entityTypeManager->getDefinition($entity_type)->getKey('langcode') . ':language';
         $entity->addSelectionCondition(
           [
             'id' => 'language',
             'langcodes' => array_combine($languages, $languages),
             'negate' => FALSE,
             'context_mapping' => [
-              'language' => $entity_type . ':' . $this->entityTypeManager->getDefinition($entity_type)->getKey('langcode') . ':language',
+              'language' => $language_mapping,
             ]
           ]
         );
+        $new_definition = new ContextDefinition('language', 'Language');
+        $new_context = new Context($new_definition);
+        $entity->addContext($language_mapping, $new_context);
       }
 
     }


### PR DESCRIPTION
This is a work in progress for https://github.com/md-systems/pathauto/issues/110. It converts patterns from config objects to config entities.

Given the following setup:

![image](https://cloud.githubusercontent.com/assets/108130/12035192/6ea37f8a-ae3a-11e5-92ec-43a03b2af9c9.png)

After running database updates, we get this message:

![selection_003](https://cloud.githubusercontent.com/assets/108130/12035207/7f5327c2-ae3a-11e5-801d-767c9462a278.png)

Finally, when we open the patterns section, we can see that they have been created:

![selection_004](https://cloud.githubusercontent.com/assets/108130/12035211/90b6fa52-ae3a-11e5-82d1-5c86e3492a25.png)
## TODO
- [x] Process forum entities.
- [x] Figure out how patterns for specific languages are created at 8.x-1.x and then adjust the database update so it creates the respective config entities.
