### PR TITLE
[#113] Add tests for patterns with language conditions

### DIFF
--- a/src/PathautoGenerator.php
+++ b/src/PathautoGenerator.php
@@ -257,19 +257,20 @@ class PathautoGenerator implements PathautoGeneratorInterface {
    * {@inheritdoc}
    */
   public function getPatternByEntity(EntityInterface $entity) {
-    if (!isset($this->patterns[$entity->getEntityTypeId()][$entity->id()])) {
+    $langcode = $entity->language()->getId();
+    if (!isset($this->patterns[$entity->getEntityTypeId()][$entity->id()][$langcode])) {
       foreach ($this->getPatternByEntityType($entity->getEntityTypeId()) as $pattern) {
         if ($pattern->applies($entity)) {
-          $this->patterns[$entity->getEntityTypeId()][$entity->id()] = $pattern;
+          $this->patterns[$entity->getEntityTypeId()][$entity->id()][$langcode] = $pattern;
           break;
         }
       }
       // If still not set.
-      if (!isset($this->patterns[$entity->getEntityTypeId()][$entity->id()])) {
-        $this->patterns[$entity->getEntityTypeId()][$entity->id()] = NULL;
+      if (!isset($this->patterns[$entity->getEntityTypeId()][$entity->id()][$langcode])) {
+        $this->patterns[$entity->getEntityTypeId()][$entity->id()][$langcode] = NULL;
       }
     }
-    return $this->patterns[$entity->getEntityTypeId()][$entity->id()];
+    return $this->patterns[$entity->getEntityTypeId()][$entity->id()][$langcode];
   }
 
   /**

--- a/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
+++ b/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
@@ -179,6 +179,16 @@ class EntityAliasTypeBase extends ContextAwarePluginBase implements AliasTypeInt
     $entities = $this->entityTypeManager->getStorage($this->getEntityTypeId())->loadMultiple($ids);
     foreach ($entities as $entity) {
       \Drupal::service('pathauto.generator')->updateEntityAlias($entity, 'bulkupdate', $options);
+
+      // Create aliases for the entity translations.
+      if ($entity->isTranslatable()) {
+        foreach ($entity->getTranslationLanguages(FALSE) as $langcode => $language) {
+          if ($entity->hasTranslation($langcode)) {
+            $translated_entity = $entity->getTranslation($langcode);
+            \Drupal::service('pathauto.generator')->updateEntityAlias($translated_entity, 'bulkupdate', $options);
+          }
+        }
+      }
     }
 
     if (!empty($options['message'])) {

--- a/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
+++ b/src/Plugin/pathauto/AliasType/EntityAliasTypeBase.php
@@ -178,16 +178,10 @@ class EntityAliasTypeBase extends ContextAwarePluginBase implements AliasTypeInt
 
     $entities = $this->entityTypeManager->getStorage($this->getEntityTypeId())->loadMultiple($ids);
     foreach ($entities as $entity) {
-      \Drupal::service('pathauto.generator')->updateEntityAlias($entity, 'bulkupdate', $options);
-
-      // Create aliases for the entity translations.
-      if ($entity->isTranslatable()) {
-        foreach ($entity->getTranslationLanguages(FALSE) as $langcode => $language) {
-          if ($entity->hasTranslation($langcode)) {
-            $translated_entity = $entity->getTranslation($langcode);
-            \Drupal::service('pathauto.generator')->updateEntityAlias($translated_entity, 'bulkupdate', $options);
-          }
-        }
+      // Update aliases for the entity's default language and its translations.
+      foreach ($entity->getTranslationLanguages() as $langcode => $language) {
+        $translated_entity = $entity->getTranslation($langcode);
+        \Drupal::service('pathauto.generator')->updateEntityAlias($translated_entity, 'bulkupdate', $options);
       }
     }
 

--- a/src/Tests/PathautoLocaleTest.php
+++ b/src/Tests/PathautoLocaleTest.php
@@ -9,9 +9,7 @@ namespace Drupal\pathauto\Tests;
 
 use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Url;
 use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\language\Entity\ContentLanguageSettings;
 use Drupal\pathauto\PathautoState;
 use Drupal\simpletest\WebTestBase;
 
@@ -97,7 +95,6 @@ class PathautoLocaleTest extends WebTestBase {
     $this->drupalLogin($this->rootUser);
 
     // Add French language.
-    // Add predefined French language.
     $edit = array(
       'predefined_langcode' => 'fr',
     );

--- a/src/Tests/PathautoLocaleTest.php
+++ b/src/Tests/PathautoLocaleTest.php
@@ -9,8 +9,6 @@ namespace Drupal\pathauto\Tests;
 
 use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Plugin\Context\Context;
-use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Url;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\language\Entity\ContentLanguageSettings;
@@ -115,44 +113,36 @@ class PathautoLocaleTest extends WebTestBase {
     $article_language_settings->save();
 
     // Create a pattern for English articles.
-    $pattern = $this->createPattern('node', '/the-articles/[node:title]');
-    $pattern->addSelectionCondition([
-      'id' => 'entity_bundle:node',
-      'bundles' => ['article' => 'article'],
-      'negate' => FALSE,
-      'context_mapping' => ['node' => 'node'],
-    ]);
-    $language_mapping = 'node:langcode:language';
-    $pattern->addSelectionCondition([
-      'id' => 'language',
-      'langcodes' => ['en' => 'en'],
-      'negate' => FALSE,
-      'context_mapping' => ['language' => $language_mapping],
-    ]);
-    $new_definition = new ContextDefinition('language', 'Language');
-    $new_context = new Context($new_definition);
-    $pattern->addContext($language_mapping, $new_context);
-    $pattern->save();
+    $this->drupalGet('admin/config/search/path/patterns/add');
+    $edit = array(
+      'type' => 'canonical_entities:node',
+    );
+    $this->drupalPostAjaxForm(NULL, $edit, 'type');
+    $edit += array(
+      'pattern' => '/the-articles/[node:title]',
+      'label' => 'English articles',
+      'id' => 'english_articles',
+      'bundles[article]' => TRUE,
+      'languages[en]' => TRUE,
+    );
+    $this->drupalPostForm(NULL, $edit, 'Save');
+    $this->assertText('Pattern English articles saved.');
 
     // Create a pattern for French articles.
-    $pattern = $this->createPattern('node', '/les-articles/[node:title]');
-    $pattern->addSelectionCondition([
-      'id' => 'entity_bundle:node',
-      'bundles' => ['article' => 'article'],
-      'negate' => FALSE,
-      'context_mapping' => ['node' => 'node'],
-    ]);
-    $language_mapping = 'node:langcode:language';
-    $pattern->addSelectionCondition([
-      'id' => 'language',
-      'langcodes' => ['fr' => 'fr'],
-      'negate' => FALSE,
-      'context_mapping' => ['language' => $language_mapping],
-    ]);
-    $new_definition = new ContextDefinition('language', 'Language');
-    $new_context = new Context($new_definition);
-    $pattern->addContext($language_mapping, $new_context);
-    $pattern->save();
+    $this->drupalGet('admin/config/search/path/patterns/add');
+    $edit = array(
+      'type' => 'canonical_entities:node',
+    );
+    $this->drupalPostAjaxForm(NULL, $edit, 'type');
+    $edit += array(
+      'pattern' => '/les-articles/[node:title]',
+      'label' => 'French articles',
+      'id' => 'french_articles',
+      'bundles[article]' => TRUE,
+      'languages[fr]' => TRUE,
+    );
+    $this->drupalPostForm(NULL, $edit, 'Save');
+    $this->assertText('Pattern French articles saved.');
 
     // Create a node and its translation. Assert aliases.
     $edit = array(

--- a/src/Tests/PathautoLocaleTest.php
+++ b/src/Tests/PathautoLocaleTest.php
@@ -37,10 +37,8 @@ class PathautoLocaleTest extends WebTestBase {
   protected function setUp() {
     parent::setUp();
 
-    // Create Article node types.
-    if ($this->profile != 'standard') {
-      $this->drupalCreateContentType(array('type' => 'article', 'name' => 'Article'));
-    }
+    // Create Article node type.
+    $this->drupalCreateContentType(array('type' => 'article', 'name' => 'Article'));
   }
 
   /**

--- a/src/Tests/PathautoLocaleTest.php
+++ b/src/Tests/PathautoLocaleTest.php
@@ -9,7 +9,11 @@ namespace Drupal\pathauto\Tests;
 
 use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Url;
 use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\language\Entity\ContentLanguageSettings;
 use Drupal\pathauto\PathautoState;
 use Drupal\simpletest\WebTestBase;
 
@@ -27,14 +31,19 @@ class PathautoLocaleTest extends WebTestBase {
    *
    * @var array
    */
-  public static $modules = array('node', 'pathauto', 'locale');
+  public static $modules = array('node', 'pathauto', 'locale', 'content_translation');
 
   /**
-   * Admin user.
-   *
-   * @var \Drupal\user\UserInterface
+   * {@inheritdoc}
    */
-  protected $adminUser;
+  protected function setUp() {
+    parent::setUp();
+
+    // Create Article node types.
+    if ($this->profile != 'standard') {
+      $this->drupalCreateContentType(array('type' => 'article', 'name' => 'Article'));
+    }
+  }
 
   /**
    * Test that when an English node is updated, its old English alias is
@@ -84,5 +93,92 @@ class PathautoLocaleTest extends WebTestBase {
     // suffix.
     $this->assertEntityAlias($node, '/content/english-node-1', LanguageInterface::LANGCODE_NOT_SPECIFIED);
   }
-}
 
+  /**
+   * Test that patterns work on multilingual content.
+   */
+  function testLanguagePatterns() {
+    $this->drupalLogin($this->rootUser);
+
+    // Add French language.
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+
+    // Enable content translation on articles.
+    \Drupal::service('content_translation.manager')->setEnabled('node', 'article', TRUE);
+    drupal_static_reset();
+    \Drupal::entityManager()->clearCachedDefinitions();
+    \Drupal::service('router.builder')->rebuild();
+    \Drupal::service('entity.definition_update_manager')->applyUpdates();
+
+    // Create a pattern for English articles.
+    $pattern = $this->createPattern('node', '/the-articles/[node:title]');
+    $pattern->addSelectionCondition([
+      'id' => 'entity_bundle:node',
+      'bundles' => ['article' => 'article'],
+      'negate' => FALSE,
+      'context_mapping' => ['node' => 'node'],
+    ]);
+    $language_mapping = 'node:langcode:language';
+    $pattern->addSelectionCondition([
+      'id' => 'language',
+      'langcodes' => ['en' => 'en'],
+      'negate' => FALSE,
+      'context_mapping' => ['language' => $language_mapping],
+    ]);
+    $new_definition = new ContextDefinition('language', 'Language');
+    $new_context = new Context($new_definition);
+    $pattern->addContext($language_mapping, $new_context);
+    $pattern->save();
+
+    // Create a pattern for French articles.
+    $pattern = $this->createPattern('node', '/les-articles/[node:title]');
+    $pattern->addSelectionCondition([
+      'id' => 'entity_bundle:node',
+      'bundles' => ['article' => 'article'],
+      'negate' => FALSE,
+      'context_mapping' => ['node' => 'node'],
+    ]);
+    $language_mapping = 'node:langcode:language';
+    $pattern->addSelectionCondition([
+      'id' => 'language',
+      'langcodes' => ['fr' => 'fr'],
+      'negate' => FALSE,
+      'context_mapping' => ['language' => $language_mapping],
+    ]);
+    $new_definition = new ContextDefinition('language', 'Language');
+    $new_context = new Context($new_definition);
+    $pattern->addContext($language_mapping, $new_context);
+    $pattern->save();
+
+    // Create a node and its translation. Assert aliases.
+    $edit = array(
+      'title[0][value]' => 'English node',
+    );
+    $this->drupalPostForm('node/add/article', $edit, t('Save and publish'));
+    $this->drupalGet('node/1/edit');
+    $english_node = $this->drupalGetNodeByTitle('English node');
+    $this->assertAlias('/node/' . $english_node->id(), '/the-articles/english-node', 'en');
+
+    $add_translation_url = Url::fromRoute('entity.node.content_translation_add', ['node' => $english_node->id(), 'source' => 'en', 'target' => 'fr']);
+    $edit = array(
+      'title[0][value]' => 'French node',
+    );
+    $this->drupalPostForm($add_translation_url, $edit, t('Save and keep published (this translation)'));
+    $this->rebuildContainer();
+    $english_node = $this->drupalGetNodeByTitle('English node');
+    $french_node = $english_node->getTranslation('fr');
+    $this->assertAlias('/node/' . $french_node->id(), '/les-articles/french-node', 'fr');
+
+    // Bulk delete and Bulk generate patterns. Assert aliases.
+    $this->deleteAllAliases();
+    // Bulk create aliases.
+    $edit = array(
+      'update[canonical_entities:node]' => TRUE,
+    );
+    $this->drupalPostForm('admin/config/search/path/update_bulk', $edit, t('Update'));
+    $this->assertText('Generated 1 URL alias.');
+    $this->assertAlias('/node/' . $english_node->id(), '/the-articles/english-node', 'en');
+    $this->assertAlias('/node/' . $french_node->id(), '/les-articles/french-node', 'fr');
+  }
+
+}


### PR DESCRIPTION
This pull request is for this issue: https://github.com/md-systems/pathauto/issues/113.

TODO:
- [x] Fix logic for bulk-generating aliases for translated content.
- [x] Refactor the logic to add a bundle and a language condition.

Here is further insight about the above two:
## Fix logic for bulk-generating aliases for translated content

There is a weird behavior at the end of the test. When using the `node/article/add` form, each node obtains the correct alias. Then, when we re-generate them, we get odd results. These are the aliases before bulk-deleting:

![selection_002](https://cloud.githubusercontent.com/assets/108130/12080501/66aaea18-b25c-11e5-9c09-8f1db535ea92.png)

Then,  we can see that they are gone after bulk deleting:
![selection_004](https://cloud.githubusercontent.com/assets/108130/12080503/73c6f138-b25c-11e5-9114-95a2d3803937.png)

Finally, this is what we get after bulk updating:
![selection_003](https://cloud.githubusercontent.com/assets/108130/12080506/89efb224-b25c-11e5-9801-2ddc4b6b4e55.png)

I have repeated what the test does manually and could verify that aliases for translations are not created when you bulk delete and bulk update.
## Refactor the logic to add a bundle and a language condition

The logic to add a bundle condition and a language condition is tricky and repetitive. We have it alread at a few places in the module:

```
juampy@Juampy/var/www/drupal8/modules/contrib/pathauto(113-test-multilingual-patterns)$ egrep -rn ContextDefinition . | grep language
./pathauto.install:180:          $new_definition = new ContextDefinition('language', 'Language');
./src/Tests/PathautoUnitTest.php:106:    $new_definition = new ContextDefinition('language', 'Language');
./src/Tests/PathautoLocaleTest.php:128:    $new_definition = new ContextDefinition('language', 'Language');
./src/Tests/PathautoLocaleTest.php:148:    $new_definition = new ContextDefinition('language', 'Language');
./src/Form/PatternEditForm.php:247:        $new_definition = new ContextDefinition('language', 'Language');
```

@Berdir, do you prefer this to be explicit or shall we add "addBundleCondition" and a "addLanguageCondition" methods to the PathautoPattern class?
