### PR TITLE
[#128] Add drupal/token 8.1.x-dev as dependency to ensure code compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,16 @@
   "name": "drupal/pathauto",
   "description": "Provides a generic set of views plugins a mechanism for modules to automatically generate aliases for the content they manage.",
   "type": "drupal-module",
-  "license": "GPL-2.0+"
+  "license": "GPL-2.0+",
+
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packagist.drupal-composer.org"
+    }
+  ],
+
+  "require": {
+    "drupal/token": "8.1.x-dev"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   ],
 
   "require": {
-    "drupal/token": "8.1.x-dev"
+    "drupal/token": "8.1.x-dev",
+    "drupal/ctools": "8.3.x-dev"
   }
 }


### PR DESCRIPTION
This makes sure that the required dependency of drupal/token will be installed where the service "token.entity_mapper" is defined.
